### PR TITLE
Add admin ads management page

### DIFF
--- a/packages/frontend/backoffice/src/components/Navbar.jsx
+++ b/packages/frontend/backoffice/src/components/Navbar.jsx
@@ -34,6 +34,10 @@ export default function Navbar() {
               Utilisateurs
             </Link>
 
+            <Link to="/admin/annonces" className="hover:text-gray-300 transition">
+              Annonces
+            </Link>
+
             <button
               onClick={handleLogout}
               className="bg-red-500 hover:bg-red-600 px-4 py-2 rounded"

--- a/packages/frontend/backoffice/src/pages/admin/AnnoncesList.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/AnnoncesList.jsx
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+import api from '../../services/api';
+
+export default function AnnoncesList() {
+  const [annonces, setAnnonces] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api.get('/annonces')
+      .then(res => setAnnonces(res.data))
+      .catch(err => console.error(err))
+      .finally(() => setLoading(false));
+  }, []);
+
+  function handleDelete(id) {
+    if (!window.confirm("Confirmer la suppression de cette annonce ?")) return;
+    api.delete(`/annonces/${id}`)
+      .then(() => setAnnonces(prev => prev.filter(a => a.id !== id)))
+      .catch(err => console.error(err));
+  }
+
+  if (loading) return <div className="p-4">Chargement...</div>;
+
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Gestion des annonces</h1>
+      <div className="overflow-x-auto">
+        <table className="min-w-full bg-white rounded shadow">
+          <thead>
+            <tr className="bg-gray-100 text-left text-sm uppercase text-gray-600">
+              <th className="p-3">Titre</th>
+              <th className="p-3">Type</th>
+              <th className="p-3">Prix</th>
+              <th className="p-3">Statut</th>
+              <th className="p-3">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {annonces.map(a => (
+              <tr key={a.id} className="border-b hover:bg-gray-50">
+                <td className="p-3">{a.titre}</td>
+                <td className="p-3">{a.type}</td>
+                <td className="p-3">{a.prix_propose} €</td>
+                <td className="p-3 capitalize">{a.statut}</td>
+                <td className="p-3">
+                  <button onClick={() => handleDelete(a.id)} className="text-red-600 hover:underline">
+                    Supprimer
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/backoffice/src/routes/AdminRoutes.jsx
+++ b/packages/frontend/backoffice/src/routes/AdminRoutes.jsx
@@ -4,6 +4,7 @@ import Dashboard from '../pages/admin/Dashboard';
 import UsersList from "../pages/admin/UsersList";
 import EditUserForm from "../pages/admin/EditUserForm";
 import UserDetails from "../pages/admin/UserDetails";
+import AnnoncesList from "../pages/admin/AnnoncesList";
 
 export default function AdminRoutes() {
   return (
@@ -13,6 +14,7 @@ export default function AdminRoutes() {
         <Route path="utilisateurs" element={<UsersList />} />
         <Route path="utilisateurs/:id/edit" element={<EditUserForm />} />
         <Route path="utilisateurs/:id" element={<UserDetails />} />
+        <Route path="annonces" element={<AnnoncesList />} />
       </Route>
     </Routes>
   );


### PR DESCRIPTION
## Summary
- manage annonces in backoffice
- link the new page in admin routes and navbar

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685bb0db29988331acee284e15e23003