### PR TITLE
Add AnnoncesList admin component

### DIFF
--- a/packages/frontend/backoffice/src/pages/admin/AnnoncesList.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/AnnoncesList.jsx
@@ -1,0 +1,181 @@
+import { useEffect, useState } from "react";
+import api from "../../services/api";
+
+export default function AnnoncesList() {
+  const [annonces, setAnnonces] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [form, setForm] = useState({ titre: "", description: "", prix_propose: "" });
+  const [editingId, setEditingId] = useState(null);
+  const [errors, setErrors] = useState({});
+
+  useEffect(() => {
+    fetchAnnonces();
+  }, []);
+
+  const fetchAnnonces = async () => {
+    try {
+      const res = await api.get("/annonces");
+      setAnnonces(res.data);
+    } catch (err) {
+      console.error(err);
+      alert("Erreur lors du chargement des annonces");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setErrors({});
+
+    if (editingId) {
+      await updateAnnonce();
+    } else {
+      await createAnnonce();
+    }
+  };
+
+  const createAnnonce = async () => {
+    try {
+      const res = await api.post("/annonces", form);
+      setAnnonces([...annonces, res.data]);
+      resetForm();
+    } catch (err) {
+      if (err.response?.data?.errors) {
+        setErrors(err.response.data.errors);
+      } else {
+        alert("Erreur lors de la création");
+      }
+    }
+  };
+
+  const updateAnnonce = async () => {
+    try {
+      const res = await api.put(`/annonces/${editingId}`, form);
+      setAnnonces(annonces.map((a) => (a.id === editingId ? res.data : a)));
+      resetForm();
+    } catch (err) {
+      if (err.response?.data?.errors) {
+        setErrors(err.response.data.errors);
+      } else {
+        alert("Erreur lors de la mise à jour");
+      }
+    }
+  };
+
+  const startEdit = (annonce) => {
+    setEditingId(annonce.id);
+    setForm({
+      titre: annonce.titre || "",
+      description: annonce.description || "",
+      prix_propose: annonce.prix_propose || "",
+    });
+    setErrors({});
+  };
+
+  const resetForm = () => {
+    setForm({ titre: "", description: "", prix_propose: "" });
+    setEditingId(null);
+  };
+
+  if (loading) return <div className="p-4">Chargement...</div>;
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold">Gestion des annonces</h1>
+
+      <form onSubmit={handleSubmit} className="bg-white shadow p-4 rounded space-y-4">
+        <h2 className="text-xl font-semibold">
+          {editingId ? "Modifier l'annonce" : "Nouvelle annonce"}
+        </h2>
+        <div>
+          <label className="block font-semibold">Titre</label>
+          <input
+            type="text"
+            name="titre"
+            value={form.titre}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+          />
+          {errors.titre && <p className="text-red-600 text-sm">{errors.titre[0]}</p>}
+        </div>
+        <div>
+          <label className="block font-semibold">Description</label>
+          <textarea
+            name="description"
+            value={form.description}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+          />
+          {errors.description && (
+            <p className="text-red-600 text-sm">{errors.description[0]}</p>
+          )}
+        </div>
+        <div>
+          <label className="block font-semibold">Prix proposé</label>
+          <input
+            type="number"
+            name="prix_propose"
+            value={form.prix_propose}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+          />
+          {errors.prix_propose && (
+            <p className="text-red-600 text-sm">{errors.prix_propose[0]}</p>
+          )}
+        </div>
+        <div className="flex gap-4">
+          <button
+            type="submit"
+            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+          >
+            {editingId ? "Mettre à jour" : "Ajouter"}
+          </button>
+          {editingId && (
+            <button
+              type="button"
+              onClick={resetForm}
+              className="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600"
+            >
+              Annuler
+            </button>
+          )}
+        </div>
+      </form>
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full bg-white rounded shadow">
+          <thead>
+            <tr className="bg-gray-100 text-left text-sm uppercase text-gray-600">
+              <th className="p-3">Titre</th>
+              <th className="p-3">Description</th>
+              <th className="p-3">Prix</th>
+              <th className="p-3">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {annonces.map((a) => (
+              <tr key={a.id} className="border-b hover:bg-gray-50">
+                <td className="p-3">{a.titre}</td>
+                <td className="p-3">{a.description}</td>
+                <td className="p-3">{a.prix_propose}</td>
+                <td className="p-3 space-x-2">
+                  <button
+                    onClick={() => startEdit(a)}
+                    className="text-yellow-600 hover:underline"
+                  >
+                    Modifier
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `AnnoncesList` component in backoffice admin pages
- list annonces from API and allow creation or update with validation display

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685bb4cf3258833195e021157d159b32