### PR TITLE
Handle distinct arrival warehouse selection

### DIFF
--- a/packages/backend/app/Http/Controllers/AnnonceController.php
+++ b/packages/backend/app/Http/Controllers/AnnonceController.php
@@ -73,7 +73,7 @@ class AnnonceController extends Controller
 
         // Si client → il faut entrepot_arrivee_id
         if ($user->role === 'client') {
-            $rules['entrepot_arrivee_id'] = 'required|exists:entrepots,id';
+            $rules['entrepot_arrivee_id'] = 'required|exists:entrepots,id|different:entrepot_depart_id';
         }
 
         $validated = $request->validate($rules);

--- a/packages/frontend/frontoffice/src/pages/CreerAnnonce.jsx
+++ b/packages/frontend/frontoffice/src/pages/CreerAnnonce.jsx
@@ -49,7 +49,13 @@ export default function CreerAnnonce() {
   }
 
   const handleChange = (e) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
+    const { name, value } = e.target;
+    setForm((prev) => {
+      if (name === "entrepot_depart_id" && value === prev.entrepot_arrivee_id) {
+        return { ...prev, entrepot_depart_id: value, entrepot_arrivee_id: "" };
+      }
+      return { ...prev, [name]: value };
+    });
   };
 
   const handlePhotoChange = (e) => {
@@ -188,11 +194,13 @@ export default function CreerAnnonce() {
             required
           >
             <option value="">Ville d'arrivée</option>
-            {entrepots.map((e) => (
-              <option key={e.id} value={e.id}>
-                {e.ville}
-              </option>
-            ))}
+            {entrepots
+              .filter((e) => e.id !== Number(form.entrepot_depart_id))
+              .map((e) => (
+                <option key={e.id} value={e.id}>
+                  {e.ville}
+                </option>
+              ))}
           </select>
         )}
 

--- a/packages/frontend/frontoffice/src/pages/MesTrajets.jsx
+++ b/packages/frontend/frontoffice/src/pages/MesTrajets.jsx
@@ -41,7 +41,13 @@ export default function MesTrajets() {
   };
 
   const handleChange = (e) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
+    const { name, value } = e.target;
+    setForm((prev) => {
+      if (name === "entrepot_depart_id" && value === prev.entrepot_arrivee_id) {
+        return { ...prev, entrepot_depart_id: value, entrepot_arrivee_id: "" };
+      }
+      return { ...prev, [name]: value };
+    });
   };
 
   const handleSubmit = async (e) => {
@@ -101,9 +107,11 @@ export default function MesTrajets() {
           className="w-full p-2 border rounded"
         >
           <option value="">Ville d’arrivée</option>
-          {entrepots.map((e) => (
-            <option key={e.id} value={e.id}>{e.ville}</option>
-          ))}
+          {entrepots
+            .filter((e) => e.id !== Number(form.entrepot_depart_id))
+            .map((e) => (
+              <option key={e.id} value={e.id}>{e.ville}</option>
+            ))}
         </select>
 
         <input


### PR DESCRIPTION
## Summary
- avoid duplicate warehouse in arrival select when creating an announcement
- filter arrival choices in driver routes too
- ensure backend validation refuses same departure and arrival warehouses

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5c9163b883318ddeaf3dc56852f5