### PR TITLE
Fix duplicate annonce creation after payment

### DIFF
--- a/packages/frontend/frontoffice/src/pages/PaiementSuccess.jsx
+++ b/packages/frontend/frontoffice/src/pages/PaiementSuccess.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import api from "../services/api";
 import { useAuth } from "../context/AuthContext";
@@ -8,8 +8,11 @@ export default function PaiementSuccess() {
   const [searchParams] = useSearchParams();
   const { token } = useAuth();
   const navigate = useNavigate();
+  const finalized = useRef(false);
 
   useEffect(() => {
+    if (finalized.current) return;
+    finalized.current = true;
     const context = searchParams.get("context");
     const annonceId = searchParams.get("annonce_id");
     const entrepotId = localStorage.getItem("reservationEntrepot");


### PR DESCRIPTION
## Summary
- prevent multiple POST requests to `/api/annonces` by guarding the effect in `PaiementSuccess`

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c5fa96c0083318c08e0712098e048