### PR TITLE
Handle payment cancellation

### DIFF
--- a/packages/frontend/frontoffice/src/pages/PaiementCancel.jsx
+++ b/packages/frontend/frontoffice/src/pages/PaiementCancel.jsx
@@ -1,0 +1,34 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+export default function PaiementCancel() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const context = localStorage.getItem("paymentContext");
+    if (context === "creer") {
+      localStorage.removeItem("annonceForm");
+      localStorage.removeItem("annoncePhoto");
+      localStorage.removeItem("paymentContext");
+      navigate("/annonces/creer?cancel=1", { replace: true });
+    } else if (context === "reserver") {
+      const annonceId = localStorage.getItem("reservationAnnonceId");
+      localStorage.removeItem("reservationEntrepot");
+      localStorage.removeItem("reservationAnnonceId");
+      localStorage.removeItem("paymentContext");
+      if (annonceId) {
+        navigate(`/annonces/${annonceId}/reserver?cancel=1`, { replace: true });
+      } else {
+        navigate("/annonces", { replace: true });
+      }
+    } else {
+      navigate("/", { replace: true });
+    }
+  }, [navigate]);
+
+  return (
+    <div className="max-w-xl mx-auto mt-10 p-6 bg-white shadow rounded">
+      <p>Redirection...</p>
+    </div>
+  );
+}

--- a/packages/frontend/frontoffice/src/routes/Router.jsx
+++ b/packages/frontend/frontoffice/src/routes/Router.jsx
@@ -18,6 +18,7 @@ import AnnonceDetail from "../pages/AnnonceDetail";
 import AdresseLivraison from "../pages/AdresseLivraison";
 import Paiement from "../pages/Paiement";
 import PaiementSuccess from "../pages/PaiementSuccess";
+import PaiementCancel from "../pages/PaiementCancel";
 import DetailsService from "../pages/DetailsService";
 import MesAnnonces from "../pages/MesAnnonces";
 import AnnoncesDisponibles from "../pages/AnnoncesDisponibles";
@@ -33,7 +34,7 @@ import MesTrajets from "../pages/MesTrajets";
 import MesEtapes from "../pages/MesEtapes";
 import ValidationCodeBox from "../pages/ValidationCodeBox";
 import SuiviAnnonce from "../pages/SuiviAnnonce";
-import ReserverAnnonce from "../pages/ReserverAnnonce"
+import ReserverAnnonce from "../pages/ReserverAnnonce";
 
 export default function AppRouter() {
   return (
@@ -45,7 +46,10 @@ export default function AppRouter() {
           <Route path="/register" element={<Register />} />
           <Route path="/register-commercant" element={<RegisterCommercant />} />
           <Route path="/register-livreur" element={<RegisterLivreur />} />
-          <Route path="/register-prestataire" element={<RegisterPrestataire />} />
+          <Route
+            path="/register-prestataire"
+            element={<RegisterPrestataire />}
+          />
           <Route
             path="/annonces"
             element={
@@ -84,7 +88,10 @@ export default function AppRouter() {
               </PrivateRoute>
             }
           />
-          <Route path="/adresse-livraison/:commandeId" element={<AdresseLivraison />} />
+          <Route
+            path="/adresse-livraison/:commandeId"
+            element={<AdresseLivraison />}
+          />
           <Route
             path="/paiement/:commandeId"
             element={
@@ -98,6 +105,14 @@ export default function AppRouter() {
             element={
               <PrivateRoute>
                 <PaiementSuccess />
+              </PrivateRoute>
+            }
+          />
+          <Route
+            path="/paiement/cancel"
+            element={
+              <PrivateRoute>
+                <PaiementCancel />
               </PrivateRoute>
             }
           />
@@ -240,7 +255,6 @@ export default function AppRouter() {
             }
           />
 
-
           <Route
             path="/notifications"
             element={
@@ -261,33 +275,32 @@ export default function AppRouter() {
             }
           />
 
-          <Route 
-            path="/etapes/:etapeId/validation-code" 
+          <Route
+            path="/etapes/:etapeId/validation-code"
             element={
               <PrivateRoute>
                 <ValidationCodeBox />
               </PrivateRoute>
-            } 
+            }
           />
 
-          <Route 
+          <Route
             path="/annonces/:annonceId/suivi"
             element={
               <PrivateRoute>
                 <SuiviAnnonce />
               </PrivateRoute>
-            } 
+            }
           />
 
-          <Route 
+          <Route
             path="/annonces/:annonceId/reserver"
             element={
               <PrivateRoute>
                 <ReserverAnnonce />
               </PrivateRoute>
-            } 
+            }
           />
-
         </Routes>
       </MainLayout>
     </Router>


### PR DESCRIPTION
## Summary
- redirect to original form with a clear error message when payment is canceled
- store checkout context before redirecting to Stripe
- detect cancel flag in creation and reservation pages
- add `PaiementCancel` page and route

## Testing
- `npm run lint` *(fails: React lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c61084fac8331bb2c3dd66eecf515