### PR TITLE
Update code validation redirect

### DIFF
--- a/packages/frontend/frontoffice/src/pages/ValidationCodeBox.jsx
+++ b/packages/frontend/frontoffice/src/pages/ValidationCodeBox.jsx
@@ -94,6 +94,13 @@ export default function ValidationCodeBox() {
         setMessage("✅ Retrait validé. Vous pouvez continuer.");
         setCode("");
         await fetchEtapeInfos();
+        // Si la validation est effectuée par un livreur, on retourne
+        // automatiquement sur la liste des étapes après un court délai
+        if (etape && !etape.est_client && !etape.est_commercant) {
+          setTimeout(() => {
+            navigate("/mes-etapes");
+          }, 1000);
+        }
       } else {
         await api.patch(`/etapes/${etapeId}/cloturer`, null, {
           headers: { Authorization: `Bearer ${token}` },


### PR DESCRIPTION
## Summary
- redirect drivers to the step list a second after validating a retrait code

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685c6694d0908331aa8d819a14fd2f21