### PR TITLE
Fix waiting message for deliverer

### DIFF
--- a/packages/frontend/frontoffice/src/pages/MesEtapes.jsx
+++ b/packages/frontend/frontoffice/src/pages/MesEtapes.jsx
@@ -60,6 +60,8 @@ export default function MesEtapes() {
                   Saisir le code pour retirer
                 </Link>
               );
+            } else if (!codeRetrait?.utilise && !e.est_client && !e.est_commercant) {
+              infoMessage = "⏳ En attente de retrait par vous";
             } else if (!codeRetrait?.utilise && !colisEstDisponible) {
               infoMessage = "⏳ En attente de dépôt du commerçant ou client";
             } else if (!codeDepot?.utilise && codeDepot) {


### PR DESCRIPTION
## Summary
- update MesEtapes waiting logic to show deliverer message

## Testing
- `npm run lint` *(fails: several lint errors in unrelated files)*
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c6b7bf5fc8331a429f45e68462016