### PR TITLE
Hide reserved product listings

### DIFF
--- a/packages/frontend/frontoffice/src/pages/Annonces.jsx
+++ b/packages/frontend/frontoffice/src/pages/Annonces.jsx
@@ -22,7 +22,12 @@ export default function Annonces() {
         });
 
         // Filtrer uniquement les annonces de type "produit_livre"
-        const annoncesFiltrees = res.data.filter(a => a.type === "produit_livre");
+        // et non déjà réservées (id_client défini ET au moins une étape créée)
+        const annoncesFiltrees = res.data.filter((a) => {
+          if (a.type !== "produit_livre") return false;
+          const dejaReservee = a.id_client && a.etapes_livraison?.length > 0;
+          return !dejaReservee;
+        });
         setAnnonces(annoncesFiltrees);
       } catch (error) {
         console.error("Erreur lors du chargement des annonces :", error);


### PR DESCRIPTION
## Summary
- ignore reserved `produit_livre` ads on the client list

## Testing
- `npx eslint src/pages/Annonces.jsx`

------
https://chatgpt.com/codex/tasks/task_e_685cfeb2ad948331a011921d7b83e2ed