### PR TITLE
Fix message for in-progress step

### DIFF
--- a/packages/frontend/frontoffice/src/pages/MesEtapes.jsx
+++ b/packages/frontend/frontoffice/src/pages/MesEtapes.jsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
 import api from "../services/api";
 import { useAuth } from "../context/AuthContext";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 export default function MesEtapes() {
   const { token } = useAuth();
+  const navigate = useNavigate();
   const [etapes, setEtapes] = useState([]);
   const [toutesEtapes, setToutesEtapes] = useState([]);
 
@@ -60,10 +61,22 @@ export default function MesEtapes() {
                   Saisir le code pour retirer
                 </Link>
               );
-            } else if (!codeRetrait?.utilise && !e.est_client && !e.est_commercant) {
-              infoMessage = "⏳ En attente de retrait par vous";
-            } else if (!codeRetrait?.utilise && !colisEstDisponible) {
-              infoMessage = "⏳ En attente de dépôt du commerçant ou client";
+            } else if (!codeRetrait?.utilise && e.statut === "en_cours") {
+              if (e.est_client || e.est_commercant) {
+                infoMessage = "⏳ En attente de dépôt du commerçant ou client";
+              } else {
+                infoMessage = "⏳ En attente de retrait par vous";
+                boutonAction = (
+                  <button
+                    onClick={() =>
+                      navigate(`/validation-code/${e.id}?type=retrait`)
+                    }
+                    className="inline-block mt-3 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+                  >
+                    Saisir le code pour retirer
+                  </button>
+                );
+              }
             } else if (!codeDepot?.utilise && codeDepot) {
               infoMessage = "📦 Prêt pour dépôt à l'arrivée";
               boutonAction = (


### PR DESCRIPTION
## Summary
- correct the message displayed for an in-progress step depending on the actor
- show retrieval validation button for deliverers when their step is in progress

## Testing
- `npm install`
- `npm run lint` *(fails: 17 problems)*

------
https://chatgpt.com/codex/tasks/task_e_685d01f2b58483318ba0328f907cefd8