### PR TITLE
Fix withdrawal step detection for deliverer

### DIFF
--- a/packages/frontend/frontoffice/src/pages/ValidationCodeBox.jsx
+++ b/packages/frontend/frontoffice/src/pages/ValidationCodeBox.jsx
@@ -47,7 +47,8 @@ export default function ValidationCodeBox() {
 
           const depotEffectue = annonceEtapes.data.etapes_livraison?.some(
             (et) =>
-              (et.est_client || et.est_commercant) &&
+              et.id !== e.id &&
+              et.lieu_arrivee === e.lieu_depart &&
               et.codes?.some((c) => c.type === "depot" && c.utilise === true)
           );
 


### PR DESCRIPTION
## Summary
- correct deposit check in ValidationCodeBox so a following deliverer can unlock the withdrawal step

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d05c81ecc8331941be83264638953