### PR TITLE
Fix code validation flow

### DIFF
--- a/packages/backend/app/Http/Controllers/EtapeLivraisonController.php
+++ b/packages/backend/app/Http/Controllers/EtapeLivraisonController.php
@@ -137,6 +137,14 @@ class EtapeLivraisonController extends Controller
             return response()->json(['message' => 'Non autorisé.'], 403);
         }
 
+        // Blocage : un retrait ne peut être validé si une étape client ou
+        // commerçant précédente de la même annonce n'est pas terminée.
+        if ($request->type === 'retrait' && ! $etape->peutRetirer()) {
+            return response()->json([
+                'message' => 'Le colis n\'a pas encore été déposé.'
+            ], 400);
+        }
+
         $codeBox = CodeBox::where('etape_livraison_id', $etape->id)
             ->where('type', $request->type)
             ->where('code_temporaire', $request->code)

--- a/packages/backend/app/Models/EtapeLivraison.php
+++ b/packages/backend/app/Models/EtapeLivraison.php
@@ -40,4 +40,20 @@ class EtapeLivraison extends Model
     {
         return $this->hasMany(CodeBox::class, 'etape_livraison_id');
     }
+
+    /**
+     * Détermine si le retrait peut être validé pour cette étape.
+     * Il ne doit exister aucune étape précédente de la même annonce
+     * créée pour le client ou le commerçant qui n'est pas encore terminée.
+     */
+    public function peutRetirer(): bool
+    {
+        return !self::where('annonce_id', $this->annonce_id)
+            ->where(function ($q) {
+                $q->where('est_client', true)->orWhere('est_commercant', true);
+            })
+            ->where('statut', '!=', 'terminee')
+            ->where('created_at', '<', $this->created_at)
+            ->exists();
+    }
 }

--- a/packages/frontend/frontoffice/src/pages/MesEtapes.jsx
+++ b/packages/frontend/frontoffice/src/pages/MesEtapes.jsx
@@ -44,27 +44,36 @@ export default function MesEtapes() {
             let infoMessage = "";
             let boutonAction = null;
 
-            // ✅ Vérifie si un dépôt a été effectué par le client ou le commerçant
+            // Étapes client/commerçant précédentes non terminées pour la même annonce
+            const etapeBlocante = toutesEtapes.some(
+              (et) =>
+                et.annonce_id === e.annonce_id &&
+                (et.est_client === true || et.est_commercant === true) &&
+                et.statut !== "terminee" &&
+                new Date(et.created_at) < new Date(e.created_at)
+            );
+
             const colisEstDisponible = toutesEtapes.some(
               (et) =>
+                et.annonce_id === e.annonce_id &&
                 (et.est_client === true || et.est_commercant === true) &&
                 et.codes?.some((c) => c.type === "depot" && c.utilise)
             );
 
-            if (!codeRetrait?.utilise && colisEstDisponible) {
-              infoMessage = "🔓 Prêt pour retrait du colis";
-              boutonAction = (
-                <Link
-                  to={`/validation-code/${e.id}?type=retrait`}
-                  className="inline-block mt-3 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
-                >
-                  Saisir le code pour retirer
-                </Link>
-              );
-            } else if (!codeRetrait?.utilise && e.statut === "en_cours") {
-              if (e.est_client || e.est_commercant) {
+            if (!codeRetrait?.utilise && e.statut === "en_cours") {
+              if (etapeBlocante) {
                 infoMessage = "⏳ En attente de dépôt du commerçant ou client";
-              } else {
+              } else if (colisEstDisponible) {
+                infoMessage = "🔓 Prêt pour retrait du colis";
+                boutonAction = (
+                  <Link
+                    to={`/validation-code/${e.id}?type=retrait`}
+                    className="inline-block mt-3 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+                  >
+                    Saisir le code pour retirer
+                  </Link>
+                );
+              } else if (!e.est_client && !e.est_commercant) {
                 infoMessage = "⏳ En attente de retrait par vous";
                 boutonAction = (
                   <button


### PR DESCRIPTION
## Summary
- add `peutRetirer` helper on `EtapeLivraison`
- forbid withdrawal if previous deposit step not done
- check deposit step status on front when showing actions
- block access to code validation page when deposit step pending

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_685d0ea84344833198fef33b13d3f930