### PR TITLE
Add validation for warehouse differences

### DIFF
--- a/packages/backend/app/Http/Controllers/AnnonceController.php
+++ b/packages/backend/app/Http/Controllers/AnnonceController.php
@@ -73,7 +73,11 @@ class AnnonceController extends Controller
 
         // Si client → il faut entrepot_arrivee_id
         if ($user->role === 'client') {
-            $rules['entrepot_arrivee_id'] = 'required|exists:entrepots,id|different:entrepot_depart_id';
+            $rules['entrepot_arrivee_id'] = 'required|exists:entrepots,id';
+        }
+
+        if ($request->type === 'livraison_client') {
+            $rules['entrepot_arrivee_id'] = ($rules['entrepot_arrivee_id'] ?? 'required|exists:entrepots,id') . '|different:entrepot_depart_id';
         }
 
         $validated = $request->validate($rules);
@@ -341,6 +345,12 @@ class AnnonceController extends Controller
         if ($annonce->type !== 'produit_livre') {
             return response()->json(['message' => 'Cette annonce ne peut pas être réservée.'], 400);
         }
+
+        abort_if(
+            $request->entrepot_arrivee_id == $annonce->entrepot_depart_id,
+            422,
+            "L'entrepôt d'arrivée doit être différent de l'entrepôt de départ."
+        );
 
         if ($annonce->id_client !== null || $annonce->entrepot_arrivee_id !== null) {
             return response()->json(['message' => 'Annonce déjà réservée.'], 400);

--- a/packages/backend/app/Http/Controllers/TrajetLivreurController.php
+++ b/packages/backend/app/Http/Controllers/TrajetLivreurController.php
@@ -31,6 +31,12 @@ class TrajetLivreurController extends Controller
             'disponible_au' => 'nullable|date|after_or_equal:disponible_du',
         ]);
 
+        abort_if(
+            $validated['entrepot_depart_id'] == $validated['entrepot_arrivee_id'],
+            422,
+            "L'entrepôt d'arrivée doit être différent de l'entrepôt de départ."
+        );
+
         $trajet = TrajetLivreur::create([
             'livreur_id' => $user->id,
             ...$validated


### PR DESCRIPTION
## Summary
- improve annonce creation validation so the arrival warehouse can't match the departure warehouse
- prevent reserving a `produit_livre` annonce with the same arrival and departure
- validate trajet creation to ensure distinct warehouses

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d627c15308331a1f700de288a6696