### PR TITLE
Implement mandatory deposit code generation

### DIFF
--- a/packages/backend/app/Http/Controllers/AnnonceController.php
+++ b/packages/backend/app/Http/Controllers/AnnonceController.php
@@ -339,6 +339,7 @@ class AnnonceController extends Controller
                 'statut' => 'en_cours',
                 'est_client' => false,
                 'est_commercant' => false,
+                'est_mini_etape' => false,
             ]);
 
             if ($boxId) {
@@ -346,17 +347,15 @@ class AnnonceController extends Controller
                     'box_id' => $boxId,
                     'etape_livraison_id' => $etapeLivreur->id,
                     'type' => 'retrait',
-                    'code_temporaire' => Str::upper(Str::random(6)),
+                    'code_temporaire' => Str::random(6),
                 ]);
 
-                if ($trajet->entrepotArrivee->id !== $annonce->entrepot_arrivee_id) {
-                    CodeBox::create([
-                        'box_id' => $boxId,
-                        'etape_livraison_id' => $etapeLivreur->id,
-                        'type' => 'depot',
-                        'code_temporaire' => Str::upper(Str::random(6)),
-                    ]);
-                }
+                CodeBox::create([
+                    'box_id' => $boxId,
+                    'etape_livraison_id' => $etapeLivreur->id,
+                    'type' => 'depot',
+                    'code_temporaire' => Str::random(6),
+                ]);
             }
 
             return response()->json([
@@ -380,13 +379,14 @@ class AnnonceController extends Controller
             'statut' => 'en_cours',
             'est_client' => true,
             'est_commercant' => false,
+            'est_mini_etape' => false,
         ]);
 
         CodeBox::create([
             'box_id' => $box->id,
             'etape_livraison_id' => $etapeClient->id,
             'type' => 'depot',
-            'code_temporaire' => Str::upper(Str::random(6)),
+            'code_temporaire' => Str::random(6),
         ]);
 
         $box->est_occupe = true;

--- a/packages/backend/app/Http/Controllers/EtapeLivraisonController.php
+++ b/packages/backend/app/Http/Controllers/EtapeLivraisonController.php
@@ -199,23 +199,22 @@ class EtapeLivraisonController extends Controller
                 'statut' => 'en_cours',
                 'est_client' => false,
                 'est_commercant' => false,
+                'est_mini_etape' => false,
             ]);
 
             CodeBox::create([
                 'box_id' => $codeBox->box_id,
                 'etape_livraison_id' => $etapeLivreur->id,
                 'type' => 'retrait',
-                'code_temporaire' => Str::upper(Str::random(6)),
+                'code_temporaire' => Str::random(6),
             ]);
 
-            if ($trajet->entrepotArrivee->id !== $annonce->entrepot_arrivee_id) {
-                CodeBox::create([
-                    'box_id' => $codeBox->box_id,
-                    'etape_livraison_id' => $etapeLivreur->id,
-                    'type' => 'depot',
-                    'code_temporaire' => Str::upper(Str::random(6)),
-                ]);
-            }
+            CodeBox::create([
+                'box_id' => $codeBox->box_id,
+                'etape_livraison_id' => $etapeLivreur->id,
+                'type' => 'depot',
+                'code_temporaire' => Str::random(6),
+            ]);
 
             return response()->json(['message' => 'Code de dépôt client validé. Étape clôturée.']);
         }
@@ -259,6 +258,7 @@ class EtapeLivraisonController extends Controller
                         'statut' => 'en_cours',
                         'est_client' => true,
                         'est_commercant' => false,
+                        'est_mini_etape' => true,
                     ]);
 
                     $box = Entrepot::where('ville', $etape->lieu_arrivee)
@@ -271,7 +271,7 @@ class EtapeLivraisonController extends Controller
                             'box_id' => $box->id,
                             'etape_livraison_id' => $etapeClient->id,
                             'type' => 'retrait',
-                            'code_temporaire' => Str::upper(Str::random(6)),
+                            'code_temporaire' => Str::random(6),
                         ]);
 
                         $box->est_occupe = true;

--- a/packages/backend/app/Models/EtapeLivraison.php
+++ b/packages/backend/app/Models/EtapeLivraison.php
@@ -19,11 +19,13 @@ class EtapeLivraison extends Model
         'statut',
         'est_client',
         'est_commercant',
+        'est_mini_etape',
     ];
 
     protected $casts = [
         'est_client' => 'boolean',
         'est_commercant' => 'boolean',
+        'est_mini_etape' => 'boolean',
     ];
 
     public function annonce()

--- a/packages/backend/database/migrations/2025_07_01_000000_add_est_mini_etape_to_etapes_livraison_again.php
+++ b/packages/backend/database/migrations/2025_07_01_000000_add_est_mini_etape_to_etapes_livraison_again.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('etapes_livraison', function (Blueprint $table) {
+            if (!Schema::hasColumn('etapes_livraison', 'est_mini_etape')) {
+                $table->boolean('est_mini_etape')->default(false)->after('est_commercant');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('etapes_livraison', function (Blueprint $table) {
+            if (Schema::hasColumn('etapes_livraison', 'est_mini_etape')) {
+                $table->dropColumn('est_mini_etape');
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- always generate deposit code for new delivery steps
- support mini-step flag on delivery steps
- create migration to add `est_mini_etape` field
- update code to mark final client mini-step

## Testing
- `composer` not available, so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_685d75f39b308331b6ca9a2f1687d744