### PR TITLE
Fix validation logic for delivery steps

### DIFF
--- a/packages/frontend/frontoffice/src/pages/SuiviAnnonce.jsx
+++ b/packages/frontend/frontoffice/src/pages/SuiviAnnonce.jsx
@@ -33,16 +33,24 @@ export default function SuiviAnnonce() {
 
   const etapesClient = annonce.etapes_livraison?.filter((e) => e.est_client);
 
-  const etapeDepotClient = etapesClient?.find((e) =>
-    e.codes?.some((c) => c.type === "depot" && !c.utilise)
+  const etapeDepotClient = etapesClient?.find(
+    (e) =>
+      e.statut === "en_cours" &&
+      e.codes?.some((c) => c.type === "depot" && !c.utilise)
   );
 
   const depotEffectue = etapesClient?.some((e) =>
     e.codes?.some((c) => c.type === "depot" && c.utilise)
   );
 
-  const etapeRetraitClient = etapesClient?.find((e) =>
-    e.codes?.some((c) => c.type === "retrait" && !c.utilise)
+  const retraitEffectue = etapesClient?.some((e) =>
+    e.codes?.some((c) => c.type === "retrait" && c.utilise)
+  );
+
+  const etapeRetraitClient = etapesClient?.find(
+    (e) =>
+      e.statut === "en_cours" &&
+      e.codes?.some((c) => c.type === "retrait" && !c.utilise)
   );
 
   const validerCode = async (type, etape_id) => {
@@ -86,9 +94,9 @@ export default function SuiviAnnonce() {
         />
       )}
 
-      {depotEffectue && (
-        <p className="text-green-600 font-semibold mt-4">
-          ✅ Dépôt effectué. En attente du retrait du livreur.
+      {depotEffectue && !etapeRetraitClient && !retraitEffectue && (
+        <p className="text-gray-600 font-medium mt-4">
+          ⏳ Colis en cours d'acheminement.
         </p>
       )}
 
@@ -103,6 +111,12 @@ export default function SuiviAnnonce() {
           etatCode={etatCode}
           isRetrait
         />
+      )}
+
+      {retraitEffectue && (
+        <p className="text-green-600 font-semibold mt-4">
+          ✅ Colis retiré. Livraison terminée.
+        </p>
       )}
     </div>
   );

--- a/packages/frontend/frontoffice/src/pages/ValidationCodeBox.jsx
+++ b/packages/frontend/frontoffice/src/pages/ValidationCodeBox.jsx
@@ -25,11 +25,25 @@ export default function ValidationCodeBox() {
 
       const e = res.data;
 
-      // Vérifie que l'étape appartient au livreur connecté
-      if (e.livreur_id !== user.id) {
-        setError("Étape non autorisée.");
-        setStep(null);
-        return;
+      // Vérifie que l'utilisateur correspond au rôle attendu pour l'étape
+      if (e.est_client) {
+        if (user.role !== "client") {
+          setError("Étape réservée au client.");
+          setStep(null);
+          return;
+        }
+      } else if (e.est_commercant) {
+        if (user.role !== "commercant") {
+          setError("Étape réservée au commerçant.");
+          setStep(null);
+          return;
+        }
+      } else {
+        if (user.role !== "livreur" || e.livreur_id !== user.id) {
+          setError("Étape réservée au livreur.");
+          setStep(null);
+          return;
+        }
       }
 
       setEtape(e);
@@ -45,16 +59,10 @@ export default function ValidationCodeBox() {
 
       let nextStep = null;
 
-      if (e.est_client) {
-        if (depot && !depot.utilise) {
-          nextStep = "depot";
-        }
-      } else {
-        if (retrait && !retrait.utilise) {
-          nextStep = "retrait";
-        } else if (depot && !depot.utilise) {
-          nextStep = "depot";
-        }
+      if (retrait && !retrait.utilise) {
+        nextStep = "retrait";
+      } else if (depot && !depot.utilise) {
+        nextStep = "depot";
       }
 
       if (queryType && queryType !== nextStep) {


### PR DESCRIPTION
## Summary
- enforce role checks in `ValidationCodeBox`
- simplify next step determination
- clarify client messages in `SuiviAnnonce`

## Testing
- `npm run lint` *(fails: cannot find @eslint/js initially; installed dependencies then lint shows existing errors)*

------
https://chatgpt.com/codex/tasks/task_e_685d7adb43bc833180a86786b9d8841e