### PR TITLE
Remove Stripe payment from AnnonceController

### DIFF
--- a/packages/backend/app/Models/Annonce.php
+++ b/packages/backend/app/Models/Annonce.php
@@ -23,6 +23,7 @@ class Annonce extends Model
         'id_prestataire',
         'entrepot_depart_id',
         'entrepot_arrivee_id',
+        'is_paid',
     ];
 
     public function client()

--- a/packages/backend/database/migrations/2025_07_01_010000_add_is_paid_to_annonces_table.php
+++ b/packages/backend/database/migrations/2025_07_01_010000_add_is_paid_to_annonces_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('annonces', function (Blueprint $table) {
+            $table->boolean('is_paid')->default(false)->after('entrepot_arrivee_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('annonces', function (Blueprint $table) {
+            $table->dropColumn('is_paid');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add `is_paid` field to annonces table via migration
- expose `is_paid` as fillable in `Annonce` model
- Annonce creation remains a simple database insert without payment

## Testing
- `vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68629581cfc483318fbd6275e915c984