### PR TITLE
Add Stripe payment with policy

### DIFF
--- a/packages/backend/app/Policies/AnnoncePolicy.php
+++ b/packages/backend/app/Policies/AnnoncePolicy.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Annonce;
+use App\Models\Utilisateur;
+
+class AnnoncePolicy
+{
+    /**
+     * Determine whether the user can pay for the given annonce.
+     */
+    public function pay(Utilisateur $user, Annonce $annonce): bool
+    {
+        return (
+            $annonce->id_client && $annonce->id_client === $user->id
+        ) || (
+            $annonce->id_commercant && $annonce->id_commercant === $user->id
+        );
+    }
+}

--- a/packages/backend/app/Providers/AuthServiceProvider.php
+++ b/packages/backend/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Providers;
+
+use App\Models\Annonce;
+use App\Policies\AnnoncePolicy;
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    /**
+     * The policy mappings for the application.
+     *
+     * @var array<class-string, class-string>
+     */
+    protected $policies = [
+        Annonce::class => AnnoncePolicy::class,
+    ];
+
+    public function boot(): void
+    {
+        $this->registerPolicies();
+    }
+}

--- a/packages/backend/config/app.php
+++ b/packages/backend/config/app.php
@@ -128,7 +128,8 @@ return [
     
     
         //App\Providers\AppServiceProvider::class,
-        //App\Providers\AuthServiceProvider::class,// App\Providers\BroadcastServiceProvider::class,
+        App\Providers\AuthServiceProvider::class,
+        // App\Providers\BroadcastServiceProvider::class,
         //App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
         // App\Providers\Wasabi\WasabiServiceProvider::class,

--- a/packages/backend/routes/api.php
+++ b/packages/backend/routes/api.php
@@ -68,7 +68,6 @@ Route::middleware(['auth:sanctum', 'role:admin'])->group(function () {
     // Annonces
     Route::patch('/annonces/{id}', [AnnonceController::class, 'update']);
     Route::delete('/annonces/{id}', [AnnonceController::class, 'destroy']);
-    Route::post('/annonces/{id}/payer', [AnnonceController::class, 'payerAnnonce']);
 
     // Client
     Route::get('/clients', [ClientController::class, 'index']);
@@ -127,6 +126,8 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/annonces', [AnnonceController::class, 'index']);
     Route::get('/annonces/{id}', [AnnonceController::class, 'show']);
     Route::get('/mes-annonces', [AnnonceController::class, 'mesAnnonces']);
+    Route::post('/annonces/{annonce}/payer', [AnnonceController::class, 'payer'])->name('annonces.payer')->middleware('can:pay,annonce');
+    Route::get('/annonces/{annonce}/paiement-callback', [AnnonceController::class, 'paiementCallback'])->name('annonces.payer.callback');
     Route::post('/annonces', [AnnonceController::class, 'store']);
     Route::patch('/annonces/{id}', [AnnonceController::class, 'update']);
     Route::delete('/annonces/{id}', [AnnonceController::class, 'destroy']);


### PR DESCRIPTION
## Summary
- allow only annonce owner to pay
- use Stripe checkout session for paiement
- register a new policy and provider
- create callback endpoint to mark annonce paid

## Testing
- `composer` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68629ab12e2c8331a0dfb98d94f00545