### PR TITLE
Mettre à jour la logique de libération de box après retrait

### DIFF
--- a/packages/backend/app/Http/Controllers/EtapeLivraisonController.php
+++ b/packages/backend/app/Http/Controllers/EtapeLivraisonController.php
@@ -144,6 +144,15 @@ class EtapeLivraisonController extends Controller
         $codeBox->utilise = true;
         $codeBox->save();
 
+        // Libérer la box lorsque le code de retrait est validé
+        if ($request->type === 'retrait') {
+            $box = $codeBox->box;
+            if ($box) {
+                $box->est_occupe = false;
+                $box->save();
+            }
+        }
+
         // Envoi du code par email une seule fois
         if (!$codeBox->mail_envoye_at) {
             $destinataire = null;


### PR DESCRIPTION
## Summary
- release the box once a withdrawal code is validated so `est_occupe` becomes `false`

## Testing
- `composer install --no-interaction` *(fails: command not found)*
- `php -l app/Http/Controllers/EtapeLivraisonController.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686594e36ef08331b297b70176b194b7