### PR TITLE
Add success alert on user creation

### DIFF
--- a/packages/frontend/backoffice/src/pages/admin/AddUser.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/AddUser.jsx
@@ -32,6 +32,7 @@ export default function AddUser() {
 
     try {
       await api.post("/utilisateurs", form);
+      alert("Utilisateur créé !");
       navigate("/admin/utilisateurs");
     } catch (err) {
       if (err.response?.data?.errors) {


### PR DESCRIPTION
## Summary
- show a success alert after creating a user before redirecting to `/admin/utilisateurs`

## Testing
- `npm run lint` in `packages/frontend/backoffice`
- *(Failed to run backend PHP tests due to missing PHP environment)*

------
https://chatgpt.com/codex/tasks/task_e_68659af938bc8331bee2557c50acab00