### PR TITLE
Allow unpaid announcements to be visible for couriers

### DIFF
--- a/packages/backend/app/Http/Controllers/AnnonceController.php
+++ b/packages/backend/app/Http/Controllers/AnnonceController.php
@@ -221,8 +221,14 @@ class AnnonceController extends Controller
                 'client',
                 'commercant'
             ])
-            ->where('is_paid', true)
             ->whereIn('type', ['livraison_client', 'produit_livre'])
+            ->where(function ($q) {
+                $q->where('is_paid', true)
+                  ->orWhereDoesntHave('etapesLivraison', function ($q2) {
+                      $q2->where('est_client', false)
+                          ->where('statut', '!=', 'terminee');
+                  });
+            })
             ->get();
 
         $disponibles = [];


### PR DESCRIPTION
## Summary
- modify annonce listing for couriers so unpaid annonces are visible
- exclude annonces already taken by another courier

## Testing
- `./vendor/bin/phpunit --testdox` *(fails: `No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6867d5b1970883318d4a03c971193c82