### PR TITLE
Fix checkout context validation

### DIFF
--- a/packages/backend/app/Http/Controllers/PaiementController.php
+++ b/packages/backend/app/Http/Controllers/PaiementController.php
@@ -76,7 +76,10 @@ class PaiementController extends Controller
             'annonce_id' => 'nullable|integer|exists:annonces,id',
             'montant' => 'nullable|numeric|min:0',
             'type' => 'required|in:produit_livre,livraison_client',
+            'context' => 'sometimes|in:reserver,payer',
         ]);
+
+        $context = $validated['context'] ?? 'reserver';
 
         if (isset($validated['montant'])) {
             $amount = (int) ($validated['montant'] * 100);
@@ -103,7 +106,7 @@ class PaiementController extends Controller
             'success_url' => sprintf(
                 '%s/paiement/success?session_id={CHECKOUT_SESSION_ID}&context=%s&annonce_id=%s',
                 rtrim(env('FRONTEND_URL', ''), '/'),
-                $request->query('context', 'reservation'),
+                $context,
                 $validated['annonce_id'] ?? ''
             ),
             'cancel_url' => rtrim(env('FRONTEND_URL', ''), '/') . '/paiement/cancel',


### PR DESCRIPTION
## Summary
- accept `payer` context in the checkout session endpoint
- validate context parameter and default to `reserver`

## Testing
- `php -v` *(fails: command not found)*
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit --stop-on-failure` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e8727e2883318932d7948e64d92c