### PR TITLE
Fix trajet query in paiementCallback

### DIFF
--- a/packages/backend/app/Http/Controllers/AnnonceController.php
+++ b/packages/backend/app/Http/Controllers/AnnonceController.php
@@ -441,9 +441,7 @@ class AnnonceController extends Controller
 
                 $trajet = TrajetLivreur::with(['entrepotDepart', 'entrepotArrivee'])
                     ->where('livreur_id', $annonce->id_livreur_reservant)
-                    ->whereHas('entrepotDepart', function ($q) use ($entrepot) {
-                        $q->where('ville', $entrepot->ville);
-                    })
+                    ->where('entrepot_depart_id', $entrepot->id)
                     ->first();
 
                 if (! $trajet || ! $trajet->entrepotArrivee) {


### PR DESCRIPTION
## Summary
- update the trajet lookup in `paiementCallback` to use `entrepot_depart_id` instead of filtering by city

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867fc452af08331a2d10eb30660a152