### PR TITLE
Fix depot code uses arrival box

### DIFF
--- a/packages/backend/app/Http/Controllers/EtapeLivraisonController.php
+++ b/packages/backend/app/Http/Controllers/EtapeLivraisonController.php
@@ -233,21 +233,24 @@ class EtapeLivraisonController extends Controller
                         'est_mini_etape' => false,
                     ]);
 
-                    $box = $codeBox->box;
-                    if ($box) {
+                    $boxRetrait = $codeBox->box;
+                    if ($boxRetrait) {
                         CodeBox::create([
-                            'box_id' => $box->id,
+                            'box_id' => $boxRetrait->id,
                             'etape_livraison_id' => $etapeLivreur->id,
                             'type' => 'retrait',
                             'code_temporaire' => Str::random(6),
                         ]);
 
-                        CodeBox::create([
-                            'box_id' => $box->id,
-                            'etape_livraison_id' => $etapeLivreur->id,
-                            'type' => 'depot',
-                            'code_temporaire' => Str::random(6),
-                        ]);
+                        $boxDepot = Entrepot::where('ville', $etapeLivreur->lieu_arrivee)
+                            ->first()?->boxes()
+                            ->where('est_occupe', false)
+                            ->where('id', '!=', $boxRetrait->id)
+                            ->first();
+
+                        if ($boxDepot) {
+                            CodeBox::createDepotCode($etapeLivreur, $boxDepot);
+                        }
                     }
                 }
             }

--- a/packages/backend/app/Models/CodeBox.php
+++ b/packages/backend/app/Models/CodeBox.php
@@ -3,6 +3,10 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+use App\Models\Box;
+use App\Models\EtapeLivraison;
 
 class CodeBox extends Model
 {
@@ -29,5 +33,20 @@ class CodeBox extends Model
     public function box()
     {
         return $this->belongsTo(Box::class);
+    }
+
+    public static function createDepotCode(EtapeLivraison $etape, Box $box): self
+    {
+        $code = self::create([
+            'box_id' => $box->id,
+            'etape_livraison_id' => $etape->id,
+            'type' => 'depot',
+            'code_temporaire' => Str::random(6),
+        ]);
+
+        $box->est_occupe = true;
+        $box->save();
+
+        return $code;
     }
 }


### PR DESCRIPTION
## Summary
- create helper `CodeBox::createDepotCode`
- pick a free box in the arrival warehouse when opening a new step

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit --testsuite Feature` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869171491b88331895125e05ab4bd20