### PR TITLE
Add admin creation page to backoffice

### DIFF
--- a/packages/frontend/backoffice/src/pages/admin/AddAdmin.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/AddAdmin.jsx
@@ -1,0 +1,145 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import api from "../../services/api";
+
+export default function AddAdmin() {
+  const navigate = useNavigate();
+  const [form, setForm] = useState({
+    nom: "",
+    prenom: "",
+    identifiant: "",
+    password: "",
+    password_confirmation: "",
+  });
+  const [errors, setErrors] = useState({});
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setForm({ ...form, [name]: value });
+    setErrors((prev) => {
+      const updated = { ...prev };
+      delete updated[name];
+      return updated;
+    });
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setErrors({});
+
+    if (form.password !== form.password_confirmation) {
+      setErrors({ password_confirmation: ["Les mots de passe ne correspondent pas."] });
+      return;
+    }
+
+    try {
+      await api.post("/admin/register", {
+        nom: form.nom,
+        prenom: form.prenom,
+        identifiant: form.identifiant,
+        password: form.password,
+      });
+      alert("Administrateur créé !");
+      navigate("/admin/utilisateurs");
+    } catch (err) {
+      if (err.response?.data?.errors) {
+        setErrors(err.response.data.errors);
+      } else {
+        alert("Erreur lors de la création de l'administrateur");
+      }
+    }
+  };
+
+  const handleCancel = () => {
+    navigate("/admin/utilisateurs");
+  };
+
+  return (
+    <div className="max-w-3xl mx-auto p-6 bg-white shadow-md rounded">
+      <h2 className="text-2xl font-bold mb-6">Ajouter un administrateur</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block font-semibold">Nom</label>
+          <input
+            type="text"
+            name="nom"
+            value={form.nom}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+            required
+          />
+          {errors.nom && <p className="text-red-600 text-sm">{errors.nom[0]}</p>}
+        </div>
+        <div>
+          <label className="block font-semibold">Prénom</label>
+          <input
+            type="text"
+            name="prenom"
+            value={form.prenom}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+            required
+          />
+          {errors.prenom && <p className="text-red-600 text-sm">{errors.prenom[0]}</p>}
+        </div>
+        <div>
+          <label className="block font-semibold">Identifiant</label>
+          <input
+            type="text"
+            name="identifiant"
+            value={form.identifiant}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+            required
+          />
+          {errors.identifiant && (
+            <p className="text-red-600 text-sm">{errors.identifiant[0]}</p>
+          )}
+        </div>
+        <div>
+          <label className="block font-semibold">Mot de passe</label>
+          <input
+            type="password"
+            name="password"
+            value={form.password}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+            required
+          />
+          {errors.password && (
+            <p className="text-red-600 text-sm">{errors.password[0]}</p>
+          )}
+        </div>
+        <div>
+          <label className="block font-semibold">Confirmation du mot de passe</label>
+          <input
+            type="password"
+            name="password_confirmation"
+            value={form.password_confirmation}
+            onChange={handleChange}
+            className="w-full border p-2 rounded"
+            required
+          />
+          {errors.password_confirmation && (
+            <p className="text-red-600 text-sm">{errors.password_confirmation[0]}</p>
+          )}
+        </div>
+        <div className="flex gap-4">
+          <button
+            type="submit"
+            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+          >
+            Créer
+          </button>
+          <button
+            type="button"
+            onClick={handleCancel}
+            className="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600"
+          >
+            Annuler
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/packages/frontend/backoffice/src/pages/admin/UsersList.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/UsersList.jsx
@@ -20,12 +20,20 @@ export default function UsersList() {
     <div className="p-6">
       <div className="flex justify-between items-center mb-4">
         <h1 className="text-2xl font-bold">Liste des utilisateurs</h1>
-        <button
-          onClick={() => navigate("/admin/utilisateurs/ajouter")}
-          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
-        >
-          Ajouter un utilisateur
-        </button>
+        <div className="flex gap-2">
+          <button
+            onClick={() => navigate("/admin/utilisateurs/ajouter-admin")}
+            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+          >
+            Créer un admin
+          </button>
+          <button
+            onClick={() => navigate("/admin/utilisateurs/ajouter")}
+            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+          >
+            Ajouter un utilisateur
+          </button>
+        </div>
       </div>
 
       <div className="overflow-x-auto">

--- a/packages/frontend/backoffice/src/routes/AdminRoutes.jsx
+++ b/packages/frontend/backoffice/src/routes/AdminRoutes.jsx
@@ -3,6 +3,7 @@ import AdminLayout from '../layouts/AdminLayout';
 import Dashboard from '../pages/admin/Dashboard';
 import UsersList from "../pages/admin/UsersList";
 import AddUser from "../pages/admin/AddUser";
+import AddAdmin from "../pages/admin/AddAdmin";
 import EditUserForm from "../pages/admin/EditUserForm";
 import UserDetails from "../pages/admin/UserDetails";
 import AnnoncesList from "../pages/admin/AnnoncesList";
@@ -15,6 +16,7 @@ export default function AdminRoutes() {
         <Route index element={<Dashboard />} />
         <Route path="utilisateurs" element={<UsersList />} />
         <Route path="utilisateurs/ajouter" element={<AddUser />} />
+        <Route path="utilisateurs/ajouter-admin" element={<AddAdmin />} />
         <Route path="utilisateurs/:id/edit" element={<EditUserForm />} />
         <Route path="utilisateurs/:id" element={<UserDetails />} />
         <Route path="annonces" element={<AnnoncesList />} />


### PR DESCRIPTION
## Summary
- add `AddAdmin` page for admin creation
- register new admin route in `AdminRoutes`
- allow navigation from user list to the new page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68691dfe07ac833196b9b945e3ce8f18