### PR TITLE
Auto-create boxes when warehouse added

### DIFF
--- a/packages/backend/app/Observers/EntrepotObserver.php
+++ b/packages/backend/app/Observers/EntrepotObserver.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Entrepot;
+use App\Services\BoxService;
+
+class EntrepotObserver
+{
+    /**
+     * Handle the Entrepot "created" event.
+     */
+    public function created(Entrepot $entrepot): void
+    {
+        BoxService::createDefaultBoxes($entrepot);
+    }
+}

--- a/packages/backend/app/Providers/EventServiceProvider.php
+++ b/packages/backend/app/Providers/EventServiceProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Providers;
+
+use App\Models\Entrepot;
+use App\Observers\EntrepotObserver;
+use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
+
+class EventServiceProvider extends ServiceProvider
+{
+    /**
+     * The event listener mappings for the application.
+     *
+     * @var array<class-string, array<int, class-string>>
+     */
+    protected $listen = [
+        //
+    ];
+
+    public function boot(): void
+    {
+        parent::boot();
+
+        Entrepot::observe(EntrepotObserver::class);
+    }
+}

--- a/packages/backend/app/Services/BoxService.php
+++ b/packages/backend/app/Services/BoxService.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Entrepot;
+use Illuminate\Support\Str;
+
+class BoxService
+{
+    /**
+     * Create the default boxes for a warehouse.
+     */
+    public static function createDefaultBoxes(Entrepot $entrepot): void
+    {
+        $boxes = [];
+
+        for ($i = 0; $i < 5; $i++) {
+            $boxes[] = [
+                'code_box' => (string) Str::uuid(),
+                'est_occupe' => false,
+            ];
+        }
+
+        $entrepot->boxes()->createMany($boxes);
+    }
+}

--- a/packages/backend/config/app.php
+++ b/packages/backend/config/app.php
@@ -130,7 +130,7 @@ return [
         //App\Providers\AppServiceProvider::class,
         App\Providers\AuthServiceProvider::class,
         // App\Providers\BroadcastServiceProvider::class,
-        //App\Providers\EventServiceProvider::class,
+        App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
         // App\Providers\Wasabi\WasabiServiceProvider::class,
 

--- a/packages/backend/database/seeders/EntrepotsBoxesSeeder.php
+++ b/packages/backend/database/seeders/EntrepotsBoxesSeeder.php
@@ -4,7 +4,7 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use App\Models\Entrepot;
-use App\Models\Box;
+use App\Services\BoxService;
 
 class EntrepotsBoxesSeeder extends Seeder
 {
@@ -23,13 +23,7 @@ class EntrepotsBoxesSeeder extends Seeder
                 'code_postal' => rand(10000, 99999)
             ]);
 
-            for ($i = 1; $i <= 5; $i++) {
-                Box::create([
-                    'entrepot_id' => $entrepot->id,
-                    'code_box' => "BOX-{$ville}-{$i}",
-                    'est_occupe' => false
-                ]);
-            }
+            BoxService::createDefaultBoxes($entrepot);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `EntrepotObserver` and register it
- create `BoxService` for reusable box creation logic
- register observer via `EventServiceProvider`
- ensure provider is loaded in `config/app.php`
- update seeder to use new service

## Testing
- `php artisan test --stop-on-failure` *(fails: command not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686921b0354883319c6f3f968095ad02