### PR TITLE
Improve default box naming

### DIFF
--- a/packages/backend/app/Services/BoxService.php
+++ b/packages/backend/app/Services/BoxService.php
@@ -14,9 +14,9 @@ class BoxService
     {
         $boxes = [];
 
-        for ($i = 0; $i < 5; $i++) {
+        for ($i = 1; $i <= 5; $i++) {
             $boxes[] = [
-                'code_box' => (string) Str::uuid(),
+                'code_box' => 'BOX-' . Str::slug($entrepot->ville) . '-' . $i,
                 'est_occupe' => false,
             ];
         }


### PR DESCRIPTION
## Summary
- make BoxService create readable box codes using city slug

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68692786393883318cf36721cd889f32