### PR TITLE
Remove prestataire fields from annonces

### DIFF
--- a/packages/backend/app/Models/Annonce.php
+++ b/packages/backend/app/Models/Annonce.php
@@ -20,7 +20,6 @@ class Annonce extends Model
         'photo',
         'id_client',
         'id_commercant',
-        'id_prestataire',
         'id_livreur_reservant',
         'entrepot_depart_id',
         'entrepot_arrivee_id',

--- a/packages/backend/app/Models/Utilisateur.php
+++ b/packages/backend/app/Models/Utilisateur.php
@@ -39,7 +39,7 @@ class Utilisateur extends Authenticatable implements MustVerifyEmail
         }
     }
 
-    // Annonces créées par le client (type livraison_client, service ou produit_livre)
+    // Annonces créées par le client (type livraison_client ou produit_livre)
     public function annoncesClient()
     {
         return $this->hasMany(Annonce::class, 'id_client');
@@ -51,11 +51,6 @@ class Utilisateur extends Authenticatable implements MustVerifyEmail
         return $this->hasMany(Annonce::class, 'id_commercant');
     }
 
-    // Annonces créées par le prestataire (type service)
-    public function annoncesPrestataire()
-    {
-        return $this->hasMany(Annonce::class, 'id_prestataire');
-    }
 
     // Annonces pour lesquelles l'utilisateur est livreur
     public function livraisons()

--- a/packages/backend/database/migrations/2025_07_02_010000_update_annonces_remove_prestataire_and_service.php
+++ b/packages/backend/database/migrations/2025_07_02_010000_update_annonces_remove_prestataire_and_service.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('annonces', function (Blueprint $table) {
+            if (Schema::hasColumn('annonces', 'id_prestataire')) {
+                $table->dropForeign(['id_prestataire']);
+                $table->dropColumn('id_prestataire');
+            }
+        });
+
+        // Remove option 'service' from enum type
+        // PostgreSQL requires dropping check constraint
+        DB::statement("ALTER TABLE annonces DROP CONSTRAINT IF EXISTS annonces_type_check");
+        DB::statement("ALTER TABLE annonces ALTER COLUMN type TYPE VARCHAR(255)");
+        DB::statement("UPDATE annonces SET type = 'livraison_client' WHERE type = 'service'");
+        DB::statement("ALTER TABLE annonces ADD CONSTRAINT annonces_type_check CHECK (type IN ('livraison_client','produit_livre'))");
+    }
+
+    public function down(): void
+    {
+        Schema::table('annonces', function (Blueprint $table) {
+            $table->enum('type', ['livraison_client', 'produit_livre', 'service'])->change();
+            $table->unsignedBigInteger('id_prestataire')->nullable();
+            $table->foreign('id_prestataire')->references('id')->on('utilisateurs')->onDelete('cascade');
+        });
+
+        DB::statement("ALTER TABLE annonces DROP CONSTRAINT IF EXISTS annonces_type_check");
+        DB::statement("ALTER TABLE annonces ADD CONSTRAINT annonces_type_check CHECK (type IN ('livraison_client','produit_livre','service'))");
+    }
+};


### PR DESCRIPTION
## Summary
- remove prestataire reference from Annonce fillable
- drop prestataire column and `service` type in a new migration
- clean Utilisateur model

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686936a0d470833196152e0ed159173a