### PR TITLE
Fix prestation access control

### DIFF
--- a/packages/backend/app/Http/Controllers/FacturePrestataireController.php
+++ b/packages/backend/app/Http/Controllers/FacturePrestataireController.php
@@ -15,20 +15,21 @@ class FacturePrestataireController extends Controller
     public function genererFactureMensuelle($mois)
     {
         $user = Auth::user();
+        $prestataireId = $user->role === 'prestataire' ? $user->prestataire?->id : null;
 
         if ($user->role !== 'prestataire') {
             return response()->json(['message' => 'Accès réservé aux prestataires.'], 403);
         }
 
         // Vérifier si facture déjà générée
-        if (FacturePrestataire::where('prestataire_id', $user->id)->where('mois', $mois)->exists()) {
+        if (FacturePrestataire::where('prestataire_id', $prestataireId)->where('mois', $mois)->exists()) {
             return response()->json(['message' => 'Facture déjà générée pour ce mois.'], 409);
         }
 
         // Récupérer les prestations validées du mois donné
         $interventions = Intervention::with('prestation')
-            ->whereHas('prestation', function ($query) use ($user, $mois) {
-                $query->where('prestataire_id', $user->id)
+            ->whereHas('prestation', function ($query) use ($mois, $prestataireId) {
+                $query->where('prestataire_id', $prestataireId)
                     ->whereMonth('date_heure', substr($mois, 5, 2))
                     ->whereYear('date_heure', substr($mois, 0, 4))
                     ->where('statut', 'terminée');
@@ -49,11 +50,11 @@ class FacturePrestataireController extends Controller
             'prestataire' => $user
         ]);
 
-        $chemin = "factures/prestataire_{$user->id}_{$mois}.pdf";
+        $chemin = "factures/prestataire_{$prestataireId}_{$mois}.pdf";
         Storage::disk('public')->put($chemin, $pdf->output());
 
         $facture = FacturePrestataire::create([
-            'prestataire_id' => $user->id,
+            'prestataire_id' => $prestataireId,
             'mois' => $mois,
             'montant_total' => $total,
             'chemin_pdf' => $chemin,
@@ -65,13 +66,14 @@ class FacturePrestataireController extends Controller
     public function mesFactures()
     {
         $user = Auth::user();
+        $prestataireId = $user->role === 'prestataire' ? $user->prestataire?->id : null;
 
         if ($user->role !== 'prestataire') {
             return response()->json(['message' => 'Accès refusé.'], 403);
         }
 
         return response()->json(
-            FacturePrestataire::where('prestataire_id', $user->id)->latest()->get()
+            FacturePrestataire::where('prestataire_id', $prestataireId)->latest()->get()
         );
     }
 }

--- a/packages/backend/app/Http/Controllers/PlanningPrestataireController.php
+++ b/packages/backend/app/Http/Controllers/PlanningPrestataireController.php
@@ -11,13 +11,14 @@ class PlanningPrestataireController extends Controller
     public function index()
     {
         $user = Auth::user();
+        $prestataireId = $user->role === 'prestataire' ? $user->prestataire?->id : null;
 
         if ($user->role !== 'prestataire') {
             return response()->json(['message' => 'Accès réservé aux prestataires.'], 403);
         }
 
         return response()->json(
-            PlanningPrestataire::where('prestataire_id', $user->id)
+            PlanningPrestataire::where('prestataire_id', $prestataireId)
                 ->orderBy('date_disponible')
                 ->orderBy('heure_debut')
                 ->get()
@@ -27,6 +28,7 @@ class PlanningPrestataireController extends Controller
     public function store(Request $request)
     {
         $user = Auth::user();
+        $prestataireId = $user->role === 'prestataire' ? $user->prestataire?->id : null;
 
         if ($user->role !== 'prestataire') {
             return response()->json(['message' => 'Seuls les prestataires peuvent ajouter un planning.'], 403);
@@ -39,7 +41,7 @@ class PlanningPrestataireController extends Controller
         ]);
 
         $planning = PlanningPrestataire::create([
-            'prestataire_id' => $user->id,
+            'prestataire_id' => $prestataireId,
             ...$validated,
         ]);
 
@@ -49,6 +51,7 @@ class PlanningPrestataireController extends Controller
     public function destroy($id)
     {
         $user = Auth::user();
+        $prestataireId = $user->role === 'prestataire' ? $user->prestataire?->id : null;
 
         $planning = PlanningPrestataire::find($id);
 
@@ -56,7 +59,7 @@ class PlanningPrestataireController extends Controller
             return response()->json(['message' => 'Créneau introuvable.'], 404);
         }
 
-        if ($planning->prestataire_id !== $user->id) {
+        if ($user->role === 'prestataire' && $planning->prestataire_id !== $prestataireId) {
             return response()->json(['message' => 'Suppression non autorisée.'], 403);
         }
 

--- a/packages/backend/app/Http/Controllers/PrestationController.php
+++ b/packages/backend/app/Http/Controllers/PrestationController.php
@@ -67,7 +67,11 @@ class PrestationController extends Controller
         }
 
         $user = Auth::user();
-        if ($user->id !== $prestation->client_id && $user->id !== $prestation->prestataire_id) {
+        $clientId = $user->role === 'client' ? $user->client?->id : null;
+        $prestataireId = $user->role === 'prestataire' ? $user->prestataire?->id : null;
+
+        if (($user->role === 'client' && $prestation->client_id !== $clientId) ||
+            ($user->role === 'prestataire' && $prestation->prestataire_id !== $prestataireId)) {
             return response()->json(['message' => 'Accès non autorisé.'], 403);
         }
 
@@ -87,7 +91,9 @@ class PrestationController extends Controller
         }
 
         $user = Auth::user();
-        if ($user->id !== $prestation->client_id) {
+        $clientId = $user->role === 'client' ? $user->client?->id : null;
+
+        if ($user->role === 'client' && $prestation->client_id !== $clientId) {
             return response()->json(['message' => 'Modification non autorisée.'], 403);
         }
 
@@ -113,7 +119,9 @@ class PrestationController extends Controller
         }
 
         $user = Auth::user();
-        if ($user->id !== $prestation->client_id) {
+        $clientId = $user->role === 'client' ? $user->client?->id : null;
+
+        if ($user->role === 'client' && $prestation->client_id !== $clientId) {
             return response()->json(['message' => 'Suppression non autorisée.'], 403);
         }
 
@@ -129,10 +137,11 @@ class PrestationController extends Controller
     public function changerStatut(Request $request, $id)
     {
         $user = auth()->user();
+        $prestataireId = $user->role === 'prestataire' ? $user->prestataire?->id : null;
 
         $prestation = Prestation::with('prestataire')->find($id);
 
-        if (! $prestation || $user->role !== 'prestataire' || $prestation->prestataire->utilisateur_id !== $user->id) {
+        if (! $prestation || $user->role !== 'prestataire' || $prestation->prestataire_id !== $prestataireId) {
             return response()->json(['message' => 'Non autorisé.'], 403);
         }
 


### PR DESCRIPTION
## Summary
- correct access checks in PrestationController
- use related model ids when verifying Intervention permissions
- fix FacturePrestataire access checks
- secure PlanningPrestataire actions

## Testing
- `php -l app/Http/Controllers/PrestationController.php`
- `php -l app/Http/Controllers/InterventionController.php`
- `php -l app/Http/Controllers/FacturePrestataireController.php`
- `php -l app/Http/Controllers/PlanningPrestataireController.php`
- `php artisan test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_68694fcb4fa8833183c2df1a82be8dd4