### PR TITLE
Fix foreign key references for prestations

### DIFF
--- a/packages/backend/app/Http/Controllers/PrestationController.php
+++ b/packages/backend/app/Http/Controllers/PrestationController.php
@@ -95,7 +95,7 @@ class PrestationController extends Controller
         $user = Auth::user();
         $clientId = $user->role === 'client' ? $user->client?->id : null;
 
-        if ($user->role === 'client' && $prestation->client_id !== $clientId) {
+        if ($user->role !== 'admin' && $prestation->client_id !== $clientId) {
             return response()->json(['message' => 'Modification non autorisée.'], 403);
         }
 
@@ -123,7 +123,7 @@ class PrestationController extends Controller
         $user = Auth::user();
         $clientId = $user->role === 'client' ? $user->client?->id : null;
 
-        if ($user->role === 'client' && $prestation->client_id !== $clientId) {
+        if ($user->role !== 'admin' && $prestation->client_id !== $clientId) {
             return response()->json(['message' => 'Suppression non autorisée.'], 403);
         }
 

--- a/packages/backend/database/migrations/2025_07_02_020000_update_planning_prestataires_foreign_key.php
+++ b/packages/backend/database/migrations/2025_07_02_020000_update_planning_prestataires_foreign_key.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('planning_prestataires', function (Blueprint $table) {
+            $table->dropForeign(['prestataire_id']);
+            $table->foreign('prestataire_id')
+                ->references('id')->on('prestataires')
+                ->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('planning_prestataires', function (Blueprint $table) {
+            $table->dropForeign(['prestataire_id']);
+            $table->foreign('prestataire_id')
+                ->references('id')->on('utilisateurs')
+                ->onDelete('cascade');
+        });
+    }
+};

--- a/packages/backend/database/migrations/2025_07_02_021000_update_factures_prestataires_foreign_key.php
+++ b/packages/backend/database/migrations/2025_07_02_021000_update_factures_prestataires_foreign_key.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('factures_prestataires', function (Blueprint $table) {
+            $table->dropForeign(['prestataire_id']);
+            $table->foreign('prestataire_id')
+                ->references('id')->on('prestataires')
+                ->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('factures_prestataires', function (Blueprint $table) {
+            $table->dropForeign(['prestataire_id']);
+            $table->foreign('prestataire_id')
+                ->references('id')->on('utilisateurs')
+                ->onDelete('cascade');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- fix admin permissions for updating/deleting prestations
- add migrations to correct prestataire_id foreign keys for planning and facture tables

## Testing
- `composer install` *(fails: stripe/stripe-php missing in lock file)*

------
https://chatgpt.com/codex/tasks/task_e_686962597cb48331826d598b0d5fc4f5