### PR TITLE
Add missing prestation features

### DIFF
--- a/packages/backend/app/Console/Commands/GeneratePrestataireInvoices.php
+++ b/packages/backend/app/Console/Commands/GeneratePrestataireInvoices.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Prestataire;
+use App\Services\FacturePrestataireService;
+use Illuminate\Support\Facades\Log;
+use Carbon\Carbon;
+
+class GeneratePrestataireInvoices extends Command
+{
+    protected $signature = 'prestataires:generate-invoices';
+
+    protected $description = 'Generate monthly invoices for all prestataires';
+
+    public function handle(): int
+    {
+        $mois = Carbon::now()->subMonth()->format('Y-m');
+
+        foreach (Prestataire::where('valide', true)->get() as $prestataire) {
+            try {
+                FacturePrestataireService::genererPourPrestataire($prestataire, $mois);
+            } catch (\Throwable $e) {
+                Log::error('Erreur facture prestataire '.$prestataire->id.' : '.$e->getMessage());
+            }
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/packages/backend/app/Console/Kernel.php
+++ b/packages/backend/app/Console/Kernel.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+
+class Kernel extends ConsoleKernel
+{
+    protected function schedule(Schedule $schedule): void
+    {
+        $schedule->command('prestataires:generate-invoices')->monthly();
+    }
+
+    protected function commands(): void
+    {
+        $this->load(__DIR__.'/Commands');
+    }
+}

--- a/packages/backend/app/Http/Controllers/EvaluationController.php
+++ b/packages/backend/app/Http/Controllers/EvaluationController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Intervention;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class EvaluationController extends Controller
+{
+    public function index()
+    {
+        $evaluations = Intervention::with('prestation.prestataire.utilisateur')
+            ->whereNotNull('note')
+            ->latest()
+            ->get();
+
+        return response()->json($evaluations);
+    }
+
+    public function showByCible($utilisateur_id)
+    {
+        $evaluations = Intervention::with('prestation.prestataire.utilisateur')
+            ->whereHas('prestation.prestataire', function ($q) use ($utilisateur_id) {
+                $q->where('utilisateur_id', $utilisateur_id);
+            })
+            ->whereNotNull('note')
+            ->latest()
+            ->get();
+
+        return response()->json($evaluations);
+    }
+
+    public function show($id)
+    {
+        $evaluation = Intervention::with('prestation.prestataire.utilisateur')
+            ->whereNotNull('note')
+            ->find($id);
+
+        if (! $evaluation) {
+            return response()->json(['message' => 'Évaluation introuvable.'], 404);
+        }
+
+        return response()->json($evaluation);
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'intervention_id' => 'required|exists:interventions,id',
+            'note' => 'required|integer|min:1|max:5',
+            'commentaire_client' => 'nullable|string',
+        ]);
+
+        $intervention = Intervention::with('prestation')->find($validated['intervention_id']);
+        $user = Auth::user();
+
+        if ($user->role !== 'client' || $intervention->prestation->client_id !== ($user->client->id ?? null)) {
+            return response()->json(['message' => 'Accès interdit.'], 403);
+        }
+
+        if ($intervention->note !== null) {
+            return response()->json(['message' => 'Évaluation déjà enregistrée.'], 422);
+        }
+
+        $intervention->update([
+            'note' => $validated['note'],
+            'commentaire_client' => $validated['commentaire_client'] ?? null,
+        ]);
+
+        return response()->json(['message' => 'Évaluation enregistrée.', 'evaluation' => $intervention]);
+    }
+}

--- a/packages/backend/app/Http/Controllers/PrestataireValidationController.php
+++ b/packages/backend/app/Http/Controllers/PrestataireValidationController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Prestataire;
+use App\Models\JustificatifPrestataire;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+
+class PrestataireValidationController extends Controller
+{
+    public function index($id)
+    {
+        $user = Auth::user();
+        if ($user->role !== 'admin' && $user->id !== (int) $id) {
+            return response()->json(['message' => 'Accès interdit.'], 403);
+        }
+
+        $prestataire = Prestataire::where('utilisateur_id', $id)->first();
+        if (! $prestataire) {
+            return response()->json(['message' => 'Prestataire introuvable.'], 404);
+        }
+
+        return response()->json($prestataire->justificatifs);
+    }
+
+    public function store(Request $request, $id)
+    {
+        $user = Auth::user();
+        if ($user->role !== 'prestataire' || $user->id !== (int) $id) {
+            return response()->json(['message' => 'Accès interdit.'], 403);
+        }
+
+        $request->validate([
+            'fichier' => 'required|file|mimes:pdf,jpg,jpeg,png|max:2048',
+        ]);
+
+        $prestataire = $user->prestataire;
+        $path = $request->file('fichier')->store('justificatifs', 'public');
+
+        $justificatif = JustificatifPrestataire::create([
+            'prestataire_id' => $prestataire->id,
+            'chemin' => $path,
+            'type' => $request->file('fichier')->getClientOriginalExtension(),
+        ]);
+
+        return response()->json(['message' => 'Justificatif enregistré.', 'justificatif' => $justificatif], 201);
+    }
+
+    public function valider($id)
+    {
+        $user = Auth::user();
+        if ($user->role !== 'admin') {
+            return response()->json(['message' => 'Accès interdit.'], 403);
+        }
+
+        $prestataire = Prestataire::where('utilisateur_id', $id)->first();
+        if (! $prestataire) {
+            return response()->json(['message' => 'Prestataire introuvable.'], 404);
+        }
+
+        $prestataire->valide = true;
+        $prestataire->save();
+
+        return response()->json(['message' => 'Prestataire validé.']);
+    }
+}

--- a/packages/backend/app/Http/Controllers/PrestationController.php
+++ b/packages/backend/app/Http/Controllers/PrestationController.php
@@ -254,4 +254,22 @@ class PrestationController extends Controller
         return response()->json($prestations);
     }
 
+    public function assigner(Request $request, $id)
+    {
+        $request->validate([
+            'prestataire_id' => 'required|exists:prestataires,id',
+        ]);
+
+        $prestation = Prestation::find($id);
+
+        if (! $prestation) {
+            return response()->json(['message' => 'Prestation introuvable.'], 404);
+        }
+
+        $prestation->prestataire_id = $request->prestataire_id;
+        $prestation->save();
+
+        return response()->json(['message' => 'Prestataire assigné.', 'prestation' => $prestation]);
+    }
+
 }

--- a/packages/backend/app/Models/JustificatifPrestataire.php
+++ b/packages/backend/app/Models/JustificatifPrestataire.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class JustificatifPrestataire extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'prestataire_id',
+        'chemin',
+        'type',
+    ];
+
+    public function prestataire()
+    {
+        return $this->belongsTo(Prestataire::class);
+    }
+}

--- a/packages/backend/app/Models/Prestataire.php
+++ b/packages/backend/app/Models/Prestataire.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\JustificatifPrestataire;
 
 class Prestataire extends Model
 {
@@ -34,6 +35,11 @@ class Prestataire extends Model
     public function factures()
     {
         return $this->hasMany(FacturePrestataire::class);
+    }
+
+    public function justificatifs()
+    {
+        return $this->hasMany(JustificatifPrestataire::class);
     }
 
 }

--- a/packages/backend/app/Services/FacturePrestataireService.php
+++ b/packages/backend/app/Services/FacturePrestataireService.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\FacturePrestataire;
+use App\Models\Intervention;
+use App\Models\Prestataire;
+use Barryvdh\DomPDF\Facade\Pdf;
+use Illuminate\Support\Facades\Storage;
+
+class FacturePrestataireService
+{
+    public static function genererPourPrestataire(Prestataire $prestataire, string $mois): ?FacturePrestataire
+    {
+        if (FacturePrestataire::where('prestataire_id', $prestataire->id)->where('mois', $mois)->exists()) {
+            return null;
+        }
+
+        $interventions = Intervention::with('prestation')
+            ->whereHas('prestation', function ($query) use ($mois, $prestataire) {
+                $query->where('prestataire_id', $prestataire->id)
+                    ->whereMonth('date_heure', substr($mois, 5, 2))
+                    ->whereYear('date_heure', substr($mois, 0, 4))
+                    ->where('statut', 'terminée');
+            })
+            ->get();
+
+        if ($interventions->isEmpty()) {
+            return null;
+        }
+
+        $total = $interventions->sum(fn($i) => $i->prestation->tarif);
+
+        $pdf = Pdf::loadView('factures.prestataire', [
+            'interventions' => $interventions,
+            'mois' => $mois,
+            'total' => $total,
+            'prestataire' => $prestataire->utilisateur,
+        ]);
+
+        $chemin = "factures/prestataire_{$prestataire->id}_{$mois}.pdf";
+        Storage::disk('public')->put($chemin, $pdf->output());
+
+        return FacturePrestataire::create([
+            'prestataire_id' => $prestataire->id,
+            'mois' => $mois,
+            'montant_total' => $total,
+            'chemin_pdf' => $chemin,
+        ]);
+    }
+}

--- a/packages/backend/database/migrations/2025_07_03_000000_create_justificatifs_prestataires_table.php
+++ b/packages/backend/database/migrations/2025_07_03_000000_create_justificatifs_prestataires_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('justificatifs_prestataires', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('prestataire_id')->constrained()->onDelete('cascade');
+            $table->string('chemin');
+            $table->string('type')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('justificatifs_prestataires');
+    }
+};

--- a/packages/backend/routes/api.php
+++ b/packages/backend/routes/api.php
@@ -25,6 +25,7 @@ use App\Http\Controllers\PrestationController;
 use App\Http\Controllers\PlanningPrestataireController;
 use App\Http\Controllers\InterventionController;
 use App\Http\Controllers\FacturePrestataireController;
+use App\Http\Controllers\PrestataireValidationController;
 use App\Http\Controllers\StatAdminController;
 use App\Http\Controllers\Api\EmailVerificationController;
 use Laravel\Fortify\Http\Controllers\EmailVerificationNotificationController;
@@ -73,6 +74,12 @@ Route::middleware(['auth:sanctum', 'role:admin'])->group(function () {
     Route::get('/clients/{id}', [ClientController::class, 'show']);
     Route::patch('/clients/{id}', [ClientController::class, 'update']);
 
+    // Validation prestataires
+    Route::patch('/prestataires/{id}/valider', [PrestataireValidationController::class, 'valider']);
+
+    // Assignation d'un prestataire à une prestation
+    Route::patch('/prestations/{id}/assigner', [PrestationController::class, 'assigner']);
+
 });
 
 // CLIENT uniquement
@@ -109,6 +116,8 @@ Route::middleware(['auth:sanctum', 'role:admin,prestataire'])->group(function ()
     Route::get('/prestataires/{id}', [PrestataireController::class, 'show']);
     Route::patch('/prestataires/{id}', [PrestataireController::class, 'update']);
     Route::post('/prestations', [PrestationController::class, 'store']);
+    Route::post('/prestataires/{id}/justificatifs', [PrestataireValidationController::class, 'store']);
+    Route::get('/prestataires/{id}/justificatifs', [PrestataireValidationController::class, 'index']);
 });
 
 // Routes accessibles à tout utilisateur connecté


### PR DESCRIPTION
## Summary
- handle manual prestataire validation with file upload
- expose evaluation endpoints
- assign prestataire to prestation by admin
- automate monthly invoice generation with scheduled command

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa939be808331b44361bc807e7656