### PR TITLE
Fix prestation overlaps and unique interventions

### DIFF
--- a/packages/backend/app/Http/Controllers/PlanningPrestataireController.php
+++ b/packages/backend/app/Http/Controllers/PlanningPrestataireController.php
@@ -40,6 +40,18 @@ class PlanningPrestataireController extends Controller
             'heure_fin' => 'required|date_format:H:i|after:heure_debut',
         ]);
 
+        $conflict = PlanningPrestataire::where('prestataire_id', $prestataireId)
+            ->whereDate('date_disponible', $validated['date_disponible'])
+            ->where('heure_debut', '<', $validated['heure_fin'])
+            ->where('heure_fin', '>', $validated['heure_debut'])
+            ->exists();
+
+        if ($conflict) {
+            return response()->json([
+                'message' => 'Créneau en conflit avec un autre créneau existant.'
+            ], 422);
+        }
+
         $planning = PlanningPrestataire::create([
             'prestataire_id' => $prestataireId,
             ...$validated,

--- a/packages/backend/database/migrations/2025_07_04_000000_add_unique_prestation_id_to_interventions_table.php
+++ b/packages/backend/database/migrations/2025_07_04_000000_add_unique_prestation_id_to_interventions_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        // Remove potential duplicates before adding the UNIQUE constraint
+        $duplicates = DB::table('interventions')
+            ->select('prestation_id')
+            ->groupBy('prestation_id')
+            ->havingRaw('COUNT(*) > 1')
+            ->get();
+
+        foreach ($duplicates as $dup) {
+            $ids = DB::table('interventions')
+                ->where('prestation_id', $dup->prestation_id)
+                ->orderBy('id')
+                ->pluck('id')
+                ->toArray();
+
+            array_shift($ids); // keep the earliest record
+
+            if (! empty($ids)) {
+                DB::table('interventions')->whereIn('id', $ids)->delete();
+            }
+        }
+
+        Schema::table('interventions', function (Blueprint $table) {
+            $table->unique('prestation_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('interventions', function (Blueprint $table) {
+            $table->dropUnique(['prestation_id']);
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- prevent overlapping time slots for provider plannings
- guarantee one intervention per prestation at the DB level

## Testing
- `php --version` *(fails: command not found)*
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b984167c883319c3535b64d14380a