### PR TITLE
Implement prestations catalogue and detail pages

### DIFF
--- a/packages/frontend/frontoffice/CHECKLIST_PRESTATIONS.md
+++ b/packages/frontend/frontoffice/CHECKLIST_PRESTATIONS.md
@@ -4,30 +4,30 @@
 
 - [x] Nettoyer les anciens fichiers inutiles (déjà fait par Codex)
 - [x] Créer la structure unifiée des pages (déjà fait par Codex)
-- [ ] Mettre en place gestion utilisateur connecté (auth + rôle client/prestataire)
-- [ ] Installer React Query (ou Axios) pour gestion des appels API
-- [ ] Créer un layout de base (header/footer/route guards si besoin)
+- [x] Mettre en place gestion utilisateur connecté (auth + rôle client/prestataire)
+- [x] Installer React Query (ou Axios) pour gestion des appels API
+- [x] Créer un layout de base (header/footer/route guards si besoin)
 
 ---
 
 ### 📄 Pages principales
 
 #### `Catalogue.jsx` (prestations publiques)
-- [ ] Récupérer la liste des prestations disponibles via `GET /prestations/catalogue`
-- [ ] Afficher chaque prestation dans une `PrestationCard`
-- [ ] Ajouter un bouton ou lien vers `PrestationDetail.jsx` (par ID)
+- [x] Récupérer la liste des prestations disponibles via `GET /prestations/catalogue`
+- [x] Afficher chaque prestation dans une `PrestationCard`
+- [x] Ajouter un bouton ou lien vers `PrestationDetail.jsx` (par ID)
 
 #### `PrestationDetail.jsx`
-- [ ] Récupérer la prestation via `GET /prestations/:id`
-- [ ] Si client : bouton "Réserver" → `PATCH /prestations/:id/reserver`
-- [ ] Si prestataire : boutons “Accepter / Refuser / Terminer” → `PATCH /prestations/:id/statut`
-- [ ] Si prestation terminée (client) : formulaire `POST /evaluations`
-- [ ] Si prestation terminée (prestataire) : bouton `POST /interventions`
+- [x] Récupérer la prestation via `GET /prestations/:id`
+- [x] Si client : bouton "Réserver" → `PATCH /prestations/:id/reserver`
+- [x] Si prestataire : boutons “Accepter / Refuser / Terminer” → `PATCH /prestations/:id/statut`
+- [x] Si prestation terminée (client) : formulaire `POST /evaluations`
+- [x] Si prestation terminée (prestataire) : bouton `POST /interventions`
 
 #### `Prestations.jsx`
-- [ ] Récupérer les prestations de l’utilisateur connecté via `GET /prestations`
-- [ ] Filtrer selon rôle (client = réservées / prestataire = assignées)
-- [ ] Lien vers `PrestationDetail.jsx`
+- [x] Récupérer les prestations de l’utilisateur connecté via `GET /prestations`
+- [x] Filtrer selon rôle (client = réservées / prestataire = assignées)
+- [x] Lien vers `PrestationDetail.jsx`
 
 ---
 
@@ -60,7 +60,7 @@
 ---
 
 ### ♻️ Composants partagés (à créer dans `/components/`)
-- [ ] `PrestationCard.jsx`
+- [x] `PrestationCard.jsx`
 - [ ] `PrestationStatusBadge.jsx`
 - [ ] `EvaluationForm.jsx`
 - [ ] `PlanningForm.jsx`

--- a/packages/frontend/frontoffice/package-lock.json
+++ b/packages/frontend/frontoffice/package-lock.json
@@ -11,6 +11,7 @@
         "@fontsource/inter": "^5.2.5",
         "@headlessui/react": "^2.2.2",
         "@tailwindcss/vite": "^4.1.10",
+        "@tanstack/react-query": "^5.81.5",
         "axios": "^1.9.0",
         "i18next": "^25.0.2",
         "prop-types": "^15.8.1",
@@ -2269,6 +2270,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.81.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.81.5.tgz",
+      "integrity": "sha512-ZJOgCy/z2qpZXWaj/oxvodDx07XcQa9BF92c0oINjHkoqUPsmm3uG08HpTaviviZ/N9eP1f9CM7mKSEkIo7O1Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.81.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.81.5.tgz",
+      "integrity": "sha512-lOf2KqRRiYWpQT86eeeftAGnjuTR35myTP8MXyvHa81VlomoAWNEd8x5vkcAfQefu0qtYCvyqLropFZqgI2EQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.81.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-virtual": {

--- a/packages/frontend/frontoffice/package.json
+++ b/packages/frontend/frontoffice/package.json
@@ -13,6 +13,7 @@
     "@fontsource/inter": "^5.2.5",
     "@headlessui/react": "^2.2.2",
     "@tailwindcss/vite": "^4.1.10",
+    "@tanstack/react-query": "^5.81.5",
     "axios": "^1.9.0",
     "i18next": "^25.0.2",
     "prop-types": "^15.8.1",

--- a/packages/frontend/frontoffice/src/components/PrestationCard.jsx
+++ b/packages/frontend/frontoffice/src/components/PrestationCard.jsx
@@ -1,0 +1,24 @@
+import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
+
+export default function PrestationCard({ prestation }) {
+  return (
+    <div className="border rounded p-4 mb-4">
+      <h3 className="text-lg font-semibold">{prestation.type_prestation}</h3>
+      <p className="my-2">{prestation.description}</p>
+      <p>
+        Date : {new Date(prestation.date_heure).toLocaleString()} - Tarif :
+        {" "}
+        {prestation.tarif} €
+      </p>
+      {/* Lien vers la page de détail */}
+      <Link to={`/prestations/${prestation.id}`} className="text-blue-600 underline">
+        Voir détail
+      </Link>
+    </div>
+  );
+}
+
+PrestationCard.propTypes = {
+  prestation: PropTypes.object.isRequired,
+};

--- a/packages/frontend/frontoffice/src/main.jsx
+++ b/packages/frontend/frontoffice/src/main.jsx
@@ -3,11 +3,17 @@ import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './index.css';
 import { AuthProvider } from './context/AuthContext';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <AuthProvider>
-      <App />
+      {/* Fournit React Query à toute l'application */}
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
     </AuthProvider>
   </React.StrictMode>
 );

--- a/packages/frontend/frontoffice/src/pages/Catalogue.jsx
+++ b/packages/frontend/frontoffice/src/pages/Catalogue.jsx
@@ -1,8 +1,29 @@
 /* Page publique listant les prestations disponibles */
+import { useQuery } from "@tanstack/react-query";
+import api from "../services/api";
+import PrestationCard from "../components/PrestationCard";
+
 export default function Catalogue() {
+  // Récupération des prestations disponibles via React Query
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["catalogue"],
+    queryFn: async () => {
+      const res = await api.get("/prestations/catalogue");
+      return res.data;
+    },
+  });
+
+  if (isLoading) return <p>Chargement...</p>;
+  if (error) return <p>Erreur lors du chargement.</p>;
+
   return (
     <div>
-      <h2>Catalogue des prestations</h2>
+      <h2 className="text-xl font-bold mb-4">Catalogue des prestations</h2>
+      {data && data.length > 0 ? (
+        data.map((p) => <PrestationCard key={p.id} prestation={p} />)
+      ) : (
+        <p>Aucune prestation disponible.</p>
+      )}
     </div>
   );
 }

--- a/packages/frontend/frontoffice/src/pages/PrestationDetail.jsx
+++ b/packages/frontend/frontoffice/src/pages/PrestationDetail.jsx
@@ -1,8 +1,175 @@
 /* Page de détail d'une prestation avec actions de réservation ou gestion */
+import { useParams } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import api from "../services/api";
+
 export default function PrestationDetail() {
+  const { id } = useParams();
+  const { token, user } = useAuth();
+  const queryClient = useQueryClient();
+  const [note, setNote] = useState(1);
+  const [commentaire, setCommentaire] = useState("");
+
+  // Récupération de la prestation ciblée
+  const {
+    data: prestation,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ["prestation", id],
+    queryFn: async () => {
+      const res = await api.get(`/prestations/${id}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      return res.data;
+    },
+  });
+
+  // Mutation pour réserver la prestation (client)
+  const reserver = useMutation({
+    mutationFn: async () => {
+      await api.patch(`/prestations/${id}/reserver`, null, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["prestation", id] }),
+  });
+
+  // Mutation pour changer le statut (prestataire)
+  const changerStatut = useMutation({
+    mutationFn: async (statut) => {
+      await api.patch(
+        `/prestations/${id}/statut`,
+        { statut },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["prestation", id] }),
+  });
+
+  // Mutation pour valider l'intervention (prestataire)
+  const validerIntervention = useMutation({
+    mutationFn: async () => {
+      await api.post(
+        "/interventions",
+        { prestation_id: id, statut_final: "effectuée" },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["prestation", id] }),
+  });
+
+  // Mutation pour laisser une évaluation (client)
+  const noter = useMutation({
+    mutationFn: async () => {
+      await api.post(
+        "/evaluations",
+        {
+          intervention_id: prestation.intervention.id,
+          note,
+          commentaire_client: commentaire,
+        },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["prestation", id] }),
+  });
+
+  if (isLoading) return <p>Chargement...</p>;
+  if (error) return <p>Erreur lors du chargement.</p>;
+
+  const isClient = user?.role === "client";
+  const isPrestataire = user?.role === "prestataire";
+
   return (
     <div>
-      <h2>Détail de la prestation</h2>
+      <h2 className="text-xl font-bold mb-4">Détail de la prestation</h2>
+      <p className="mb-2">{prestation.description}</p>
+      <p className="mb-2">Statut : {prestation.statut}</p>
+
+      {/* Actions pour le client */}
+      {isClient && prestation.statut === "disponible" && (
+        <button
+          onClick={() => reserver.mutate()}
+          className="bg-blue-500 text-white px-4 py-2 rounded"
+        >
+          Réserver
+        </button>
+      )}
+
+      {/* Actions pour le prestataire */}
+      {isPrestataire && prestation.statut === "en_attente" && (
+        <div className="space-x-2">
+          <button
+            onClick={() => changerStatut.mutate("acceptée")}
+            className="bg-green-500 text-white px-3 py-1 rounded"
+          >
+            Accepter
+          </button>
+          <button
+            onClick={() => changerStatut.mutate("refusée")}
+            className="bg-red-500 text-white px-3 py-1 rounded"
+          >
+            Refuser
+          </button>
+        </div>
+      )}
+
+      {isPrestataire && prestation.statut === "acceptée" && (
+        <button
+          onClick={() => changerStatut.mutate("terminée")}
+          className="bg-blue-500 text-white px-4 py-2 rounded mt-2"
+        >
+          Terminer
+        </button>
+      )}
+
+      {isPrestataire && prestation.statut === "terminée" && !prestation.intervention && (
+        <button
+          onClick={() => validerIntervention.mutate()}
+          className="bg-purple-500 text-white px-4 py-2 rounded mt-2"
+        >
+          Valider l'intervention
+        </button>
+      )}
+
+      {/* Formulaire de notation pour le client */}
+      {isClient && prestation.statut === "terminée" && prestation.intervention && prestation.intervention.note === null && (
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            noter.mutate();
+          }}
+          className="mt-4 space-y-2"
+        >
+          <label>
+            Note :
+            <select
+              value={note}
+              onChange={(e) => setNote(Number(e.target.value))}
+              className="ml-2"
+            >
+              {[1, 2, 3, 4, 5].map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          </label>
+          <br />
+          <textarea
+            placeholder="Commentaire"
+            value={commentaire}
+            onChange={(e) => setCommentaire(e.target.value)}
+            className="w-full border p-2"
+          />
+          <button className="bg-green-500 text-white px-4 py-2 rounded" type="submit">
+            Noter
+          </button>
+        </form>
+      )}
     </div>
   );
 }

--- a/packages/frontend/frontoffice/src/pages/Prestations.jsx
+++ b/packages/frontend/frontoffice/src/pages/Prestations.jsx
@@ -1,8 +1,34 @@
 /* Liste des prestations de l'utilisateur connecté */
+import { useAuth } from "../context/AuthContext";
+import { useQuery } from "@tanstack/react-query";
+import api from "../services/api";
+import PrestationCard from "../components/PrestationCard";
+
 export default function Prestations() {
+  const { token } = useAuth();
+
+  // Chargement des prestations liées à l'utilisateur connecté
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["mes-prestations"],
+    queryFn: async () => {
+      const res = await api.get("/prestations", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      return res.data;
+    },
+  });
+
+  if (isLoading) return <p>Chargement...</p>;
+  if (error) return <p>Erreur lors du chargement.</p>;
+
   return (
     <div>
-      <h2>Mes prestations</h2>
+      <h2 className="text-xl font-bold mb-4">Mes prestations</h2>
+      {data && data.length > 0 ? (
+        data.map((p) => <PrestationCard key={p.id} prestation={p} />)
+      ) : (
+        <p>Aucune prestation enregistrée.</p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- mark initial setup tasks as complete in the checklist
- provide React Query setup via `QueryClientProvider`
- add `PrestationCard` component
- implement catalogue and prestations listing pages
- implement detailed view logic with reservation, status management and evaluation
- update package files to include React Query

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686bbc4a4c508331bba7fa3273332473