### PR TITLE
Remove React Query from frontoffice

### DIFF
--- a/packages/frontend/frontoffice/CHECKLIST_PRESTATIONS.md
+++ b/packages/frontend/frontoffice/CHECKLIST_PRESTATIONS.md
@@ -5,7 +5,7 @@
 - [x] Nettoyer les anciens fichiers inutiles (déjà fait par Codex)
 - [x] Créer la structure unifiée des pages (déjà fait par Codex)
 - [x] Mettre en place gestion utilisateur connecté (auth + rôle client/prestataire)
-- [x] Installer React Query (ou Axios) pour gestion des appels API
+- [x] Utiliser Axios pour la gestion des appels API (React Query retiré)
 - [x] Créer un layout de base (header/footer/route guards si besoin)
 
 ---

--- a/packages/frontend/frontoffice/package-lock.json
+++ b/packages/frontend/frontoffice/package-lock.json
@@ -11,7 +11,6 @@
         "@fontsource/inter": "^5.2.5",
         "@headlessui/react": "^2.2.2",
         "@tailwindcss/vite": "^4.1.10",
-        "@tanstack/react-query": "^5.81.5",
         "axios": "^1.9.0",
         "i18next": "^25.0.2",
         "prop-types": "^15.8.1",
@@ -2270,32 +2269,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@tanstack/query-core": {
-      "version": "5.81.5",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.81.5.tgz",
-      "integrity": "sha512-ZJOgCy/z2qpZXWaj/oxvodDx07XcQa9BF92c0oINjHkoqUPsmm3uG08HpTaviviZ/N9eP1f9CM7mKSEkIo7O1Q==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/react-query": {
-      "version": "5.81.5",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.81.5.tgz",
-      "integrity": "sha512-lOf2KqRRiYWpQT86eeeftAGnjuTR35myTP8MXyvHa81VlomoAWNEd8x5vkcAfQefu0qtYCvyqLropFZqgI2EQw==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/query-core": "5.81.5"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-virtual": {

--- a/packages/frontend/frontoffice/package.json
+++ b/packages/frontend/frontoffice/package.json
@@ -13,7 +13,6 @@
     "@fontsource/inter": "^5.2.5",
     "@headlessui/react": "^2.2.2",
     "@tailwindcss/vite": "^4.1.10",
-    "@tanstack/react-query": "^5.81.5",
     "axios": "^1.9.0",
     "i18next": "^25.0.2",
     "prop-types": "^15.8.1",

--- a/packages/frontend/frontoffice/src/main.jsx
+++ b/packages/frontend/frontoffice/src/main.jsx
@@ -3,17 +3,11 @@ import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './index.css';
 import { AuthProvider } from './context/AuthContext';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-
-const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <AuthProvider>
-      {/* Fournit React Query à toute l'application */}
-      <QueryClientProvider client={queryClient}>
-        <App />
-      </QueryClientProvider>
+      <App />
     </AuthProvider>
   </React.StrictMode>
 );

--- a/packages/frontend/frontoffice/src/pages/Catalogue.jsx
+++ b/packages/frontend/frontoffice/src/pages/Catalogue.jsx
@@ -1,19 +1,28 @@
 /* Page publique listant les prestations disponibles */
-import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
 import api from "../services/api";
 import PrestationCard from "../components/PrestationCard";
 
 export default function Catalogue() {
-  // Récupération des prestations disponibles via React Query
-  const { data, isLoading, error } = useQuery({
-    queryKey: ["catalogue"],
-    queryFn: async () => {
-      const res = await api.get("/prestations/catalogue");
-      return res.data;
-    },
-  });
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
-  if (isLoading) return <p>Chargement...</p>;
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await api.get("/prestations/catalogue");
+        setData(res.data);
+      } catch (err) {
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  if (loading) return <p>Chargement...</p>;
   if (error) return <p>Erreur lors du chargement.</p>;
 
   return (

--- a/packages/frontend/frontoffice/src/pages/Prestations.jsx
+++ b/packages/frontend/frontoffice/src/pages/Prestations.jsx
@@ -1,24 +1,32 @@
 /* Liste des prestations de l'utilisateur connecté */
+import { useEffect, useState } from "react";
 import { useAuth } from "../context/AuthContext";
-import { useQuery } from "@tanstack/react-query";
 import api from "../services/api";
 import PrestationCard from "../components/PrestationCard";
 
 export default function Prestations() {
   const { token } = useAuth();
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
-  // Chargement des prestations liées à l'utilisateur connecté
-  const { data, isLoading, error } = useQuery({
-    queryKey: ["mes-prestations"],
-    queryFn: async () => {
-      const res = await api.get("/prestations", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      return res.data;
-    },
-  });
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await api.get("/prestations", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        setData(res.data);
+      } catch (err) {
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, [token]);
 
-  if (isLoading) return <p>Chargement...</p>;
+  if (loading) return <p>Chargement...</p>;
   if (error) return <p>Erreur lors du chargement.</p>;
 
   return (


### PR DESCRIPTION
## Summary
- drop React Query usage in frontoffice pages
- fetch data with Axios via `api.js`
- clean `main.jsx` and dependencies
- update checklist accordingly

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686bc1b59d4c8331b0136555dc02256b