### PR TITLE
Secure prestation reservation

### DIFF
--- a/packages/backend/app/Http/Controllers/PrestationController.php
+++ b/packages/backend/app/Http/Controllers/PrestationController.php
@@ -212,6 +212,14 @@ class PrestationController extends Controller
             return response()->json(['message' => 'Prestation introuvable.'], 404);
         }
 
+        // Autorisation via policy
+        $this->authorize('reserver', $prestation);
+
+        // Vérifier que la prestation a été payée
+        if (! $prestation->is_paid) {
+            return response()->json(['error' => 'Paiement requis avant réservation.'], 403);
+        }
+
         if ($prestation->client_id !== null) {
             return response()->json(['message' => 'Cette prestation est déjà réservée.'], 400);
         }

--- a/packages/backend/app/Policies/PrestationPolicy.php
+++ b/packages/backend/app/Policies/PrestationPolicy.php
@@ -18,4 +18,22 @@ class PrestationPolicy
 
         return $prestation->client->utilisateur_id === $user->id;
     }
+
+    /**
+     * Determine if the authenticated user can reserve the prestation.
+     * The user must be a client and, if a client is already associated
+     * to the prestation, it must be the same one.
+     */
+    public function reserver(Utilisateur $user, Prestation $prestation): bool
+    {
+        if ($user->role !== 'client') {
+            return false;
+        }
+
+        if ($prestation->client_id) {
+            return $prestation->client->utilisateur_id === $user->id;
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
## Summary
- enforce payment check in `PrestationController::reserver`
- authorize reservation using `PrestationPolicy`
- add `reserver` method to policy

## Testing
- `npm test` *(fails: missing script)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c21a4f0988331b08369c7c4d80817