### PR TITLE
Fix catalog token usage

### DIFF
--- a/packages/frontend/frontoffice/src/pages/Catalogue.jsx
+++ b/packages/frontend/frontoffice/src/pages/Catalogue.jsx
@@ -1,5 +1,6 @@
 /* Page publique listant les prestations disponibles */
 import { useEffect, useState } from "react";
+import { useAuth } from "../context/AuthContext";
 import api from "../services/api";
 import PrestationCard from "../components/PrestationCard";
 
@@ -7,11 +8,14 @@ export default function Catalogue() {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const { token } = useAuth();
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const res = await api.get("/prestations/catalogue");
+        const res = await api.get("/prestations/catalogue", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
         setData(res.data);
       } catch (err) {
         setError(err);
@@ -20,7 +24,8 @@ export default function Catalogue() {
       }
     };
     fetchData();
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token]);
 
   if (loading) return <p>Chargement...</p>;
   if (error) return <p>Erreur lors du chargement.</p>;


### PR DESCRIPTION
## Summary
- ensure the catalogue page sends an auth token when calling `/prestations/catalogue`

## Testing
- `php artisan test` *(fails: php not found)*
- `npm run lint` in `packages/frontend/frontoffice` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_686cc6adfca88331a999c094b6d44777