### PR TITLE
Allow clients to view available prestations

### DIFF
--- a/packages/backend/app/Http/Controllers/PrestationController.php
+++ b/packages/backend/app/Http/Controllers/PrestationController.php
@@ -70,11 +70,21 @@ class PrestationController extends Controller
         }
 
         $user = Auth::user();
-        $clientId = $user->role === 'client' ? $user->client?->id : null;
+        $clientId      = $user->role === 'client' ? $user->client?->id : null;
         $prestataireId = $user->role === 'prestataire' ? $user->prestataire?->id : null;
 
-        if (($user->role === 'client' && $prestation->client_id !== $clientId) ||
-            ($user->role === 'prestataire' && $prestation->prestataire_id !== $prestataireId)) {
+        $authorized = false;
+
+        if ($user->role === 'client') {
+            $authorized = (
+                ($prestation->client_id === null && $prestation->statut === 'disponible') ||
+                $prestation->client_id === $clientId
+            );
+        } elseif ($user->role === 'prestataire') {
+            $authorized = $prestation->prestataire_id === $prestataireId;
+        }
+
+        if (! $authorized) {
             return response()->json(['message' => 'Accès non autorisé.'], 403);
         }
 


### PR DESCRIPTION
## Summary
- let clients read available prestations in `PrestationController@show`
- allow prestataires to read only their own prestation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686cd9d211dc8331b033ca5a4b9f001c