### PR TITLE
Add detailed logging for Prestation reservation policy

### DIFF
--- a/packages/backend/app/Http/Controllers/PrestationController.php
+++ b/packages/backend/app/Http/Controllers/PrestationController.php
@@ -9,6 +9,7 @@ use App\Models\Notification;
 use App\Models\PlanningPrestataire;
 use Carbon\Carbon;
 use Stripe\StripeClient;
+use Illuminate\Support\Facades\Log;
 
 class PrestationController extends Controller
 {
@@ -221,6 +222,15 @@ class PrestationController extends Controller
         if (! $prestation) {
             return response()->json(['message' => 'Prestation introuvable.'], 404);
         }
+
+        Log::info('PrestationController.reserver', [
+            'user_id' => $user->id,
+            'client_id' => $client->id,
+            'prestation_id' => $prestation->id,
+            'prestation_client_id' => $prestation->client_id,
+            'prestation_statut' => $prestation->statut,
+            'is_paid' => $prestation->is_paid,
+        ]);
 
         // Autorisation via policy
         $this->authorize('reserver', $prestation);

--- a/packages/backend/app/Policies/PrestationPolicy.php
+++ b/packages/backend/app/Policies/PrestationPolicy.php
@@ -27,12 +27,21 @@ class PrestationPolicy
      */
     public function reserver(Utilisateur $user, Prestation $prestation): bool
     {
+        Log::info('PrestationPolicy.reserver start', [
+            'user_id' => $user->id,
+            'role' => $user->role,
+            'has_client' => (bool) $user->client,
+            'prestation_id' => $prestation->id,
+            'prestation_client_id' => $prestation->client_id,
+        ]);
+
         // The requester must be a client and the relation must exist
         if ($user->role !== 'client' || ! $user->client) {
             Log::debug('PrestationPolicy.reserver: user not client or missing relation', [
                 'user_id' => $user->id,
                 'role' => $user->role,
             ]);
+            Log::info('PrestationPolicy.reserver result', ['allowed' => false]);
             return false;
         }
 
@@ -49,12 +58,16 @@ class PrestationPolicy
                     'prestation_id' => $prestation->id,
                     'client_id' => $prestation->client_id,
                 ]);
+                Log::info('PrestationPolicy.reserver result', ['allowed' => false]);
                 return false;
             }
 
-            return $prestation->client->utilisateur_id === $user->id;
+            $allowed = $prestation->client->utilisateur_id === $user->id;
+            Log::info('PrestationPolicy.reserver result', ['allowed' => $allowed]);
+            return $allowed;
         }
 
+        Log::info('PrestationPolicy.reserver result', ['allowed' => true]);
         return true;
     }
 }


### PR DESCRIPTION
## Summary
- add debug info to `PrestationPolicy::reserver`
- log reservation context in `PrestationController`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ce2ac79288331b82f9ba2edfe8950