### PR TITLE
Fix client loading in reservation flow

### DIFF
--- a/packages/backend/app/Http/Controllers/PrestationController.php
+++ b/packages/backend/app/Http/Controllers/PrestationController.php
@@ -207,6 +207,11 @@ class PrestationController extends Controller
     {
         $user = auth()->user();
 
+        // Ensure the user model includes its client relation for authorization
+        if (! $user->relationLoaded('client')) {
+            $user->load('client');
+        }
+
         if ($user->role !== 'client') {
             return response()->json(['message' => 'Seuls les clients peuvent réserver une prestation.'], 403);
         }

--- a/packages/backend/app/Policies/PrestationPolicy.php
+++ b/packages/backend/app/Policies/PrestationPolicy.php
@@ -27,6 +27,11 @@ class PrestationPolicy
      */
     public function reserver(Utilisateur $user, Prestation $prestation): bool
     {
+        // Ensure the client relation is loaded for the authenticated user
+        if (! $user->relationLoaded('client')) {
+            $user->load('client');
+        }
+
         Log::info('PrestationPolicy.reserver start', [
             'user_id' => $user->id,
             'role' => $user->role,


### PR DESCRIPTION
## Summary
- load `client` relation before checking PrestationPolicy
- ensure PrestationPolicy loads client's relation for authenticated users

## Testing
- `php -l packages/backend/app/Policies/PrestationPolicy.php` *(fails: `bash: php: command not found`)*
- `./vendor/bin/phpunit --version` *(fails: `No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_686cfd8f642083318ff709ad8a85c9d2