### PR TITLE
Disable date check for test phase

### DIFF
--- a/packages/backend/app/Http/Controllers/InterventionController.php
+++ b/packages/backend/app/Http/Controllers/InterventionController.php
@@ -52,9 +52,13 @@ class InterventionController extends Controller
         }
 
         // Empêcher la création d'une intervention avant la date de la prestation
-        if (Carbon::now()->lt($prestation->date_heure)) {
-            return response()->json(['message' => "La prestation n'a pas encore eu lieu."], 422);
-        }
+        // Désactivé temporairement pour la phase de test fonctionnel
+        // if (Carbon::now()->lt($prestation->date_heure)) {
+        //     return response()->json(['message' => "La prestation n'a pas encore eu lieu."], 422);
+        // }
+        Log::warning('Vérification date_heure désactivée pour tests', [
+            'prestation_id' => $prestation->id,
+        ]);
 
         // Empêcher la duplication d'intervention pour la même prestation
         if (Intervention::where('prestation_id', $prestation->id)->exists()) {


### PR DESCRIPTION
## Summary
- comment out date check in `InterventionController@store`
- log a warning that the check is disabled for tests

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d2767e250833189aa86b444f6b772