### PR TITLE
Add evaluation visibility and notifications

### DIFF
--- a/CHECKLIST_PRESTATIONS.md
+++ b/CHECKLIST_PRESTATIONS.md
@@ -1,0 +1,7 @@
+# Checklist Prestations
+
+## Évaluations
+- [x] Affichage des évaluations dans le profil prestataire
+- [x] Badge "Évaluée" sur les prestations
+- [x] Consultation des évaluations dans le backoffice
+- [x] Notification du prestataire à chaque évaluation

--- a/packages/backend/app/Http/Controllers/EvaluationController.php
+++ b/packages/backend/app/Http/Controllers/EvaluationController.php
@@ -6,6 +6,7 @@ use App\Models\Intervention;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Log;
+use App\Notifications\NouvelleEvaluationNotification;
 
 class EvaluationController extends Controller
 {
@@ -74,6 +75,12 @@ class EvaluationController extends Controller
             'note' => $validated['note'],
             'commentaire_client' => $validated['commentaire_client'] ?? null,
         ]);
+
+        $prestataireUser = $intervention->prestation->prestataire->utilisateur ?? null;
+        if ($prestataireUser) {
+            $prestataireUser->notify(new NouvelleEvaluationNotification($intervention));
+            Log::info('Notification nouvelle évaluation envoyée', ['prestataire_id' => $prestataireUser->id]);
+        }
 
         Log::info('Évaluation enregistrée', [
             'intervention_id' => $intervention->id,

--- a/packages/backend/app/Notifications/NouvelleEvaluationNotification.php
+++ b/packages/backend/app/Notifications/NouvelleEvaluationNotification.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Intervention;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class NouvelleEvaluationNotification extends Notification
+{
+    use Queueable;
+
+    public Intervention $intervention;
+
+    public function __construct(Intervention $intervention)
+    {
+        $this->intervention = $intervention;
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('Nouvelle évaluation reçue')
+            ->line('Une nouvelle évaluation a été reçue sur une prestation terminée.')
+            ->line('Type de prestation : ' . $this->intervention->prestation->type_prestation)
+            ->line('Note : ' . $this->intervention->note . '/5')
+            ->line('Commentaire : ' . ($this->intervention->commentaire_client ?? '')); 
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return [
+            'intervention_id' => $this->intervention->id,
+            'prestation_id' => $this->intervention->prestation_id,
+            'note' => $this->intervention->note,
+        ];
+    }
+}

--- a/packages/frontend/backoffice/src/pages/admin/AdminPrestataires.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/AdminPrestataires.jsx
@@ -5,6 +5,8 @@ export default function AdminPrestataires() {
   const [prestataires, setPrestataires] = useState([]);
   const [loading, setLoading] = useState(true);
   const [justifs, setJustifs] = useState({});
+  const [evaluations, setEvaluations] = useState({});
+  const [showEval, setShowEval] = useState({});
 
   useEffect(() => {
     fetchPrestataires();
@@ -25,6 +27,18 @@ export default function AdminPrestataires() {
     try {
       const res = await api.get(`/prestataires/${id}/justificatifs`);
       setJustifs((prev) => ({ ...prev, [id]: res.data }));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const voirEvaluations = async (utilisateurId) => {
+    try {
+      if (!evaluations[utilisateurId]) {
+        const res = await api.get(`/evaluations/cible/${utilisateurId}`);
+        setEvaluations((prev) => ({ ...prev, [utilisateurId]: res.data }));
+      }
+      setShowEval((prev) => ({ ...prev, [utilisateurId]: !prev[utilisateurId] }));
     } catch (err) {
       console.error(err);
     }
@@ -78,6 +92,9 @@ export default function AdminPrestataires() {
                   <button onClick={() => voirJustifs(p.utilisateur_id)} className="text-blue-600 hover:underline">
                     Voir justificatifs
                   </button>
+                  <button onClick={() => voirEvaluations(p.utilisateur_id)} className="text-indigo-600 hover:underline">
+                    Voir évaluations
+                  </button>
                   <button onClick={() => valider(p.utilisateur_id)} className="text-green-600 hover:underline">
                     Valider
                   </button>
@@ -103,6 +120,24 @@ export default function AdminPrestataires() {
             ))}
           </ul>
         </div>
+      ))}
+
+      {Object.entries(showEval).map(([id, visible]) => (
+        visible && evaluations[id] && (
+          <div key={`eval-${id}`} className="mt-4">
+            <h2 className="font-semibold">Évaluations utilisateur {id}</h2>
+            <ul className="list-disc ml-6">
+              {evaluations[id].map((e) => (
+                <li key={e.id} className="mb-2">
+                  <span className="font-medium">{e.prestation.type_prestation}</span>
+                  {" - "}
+                  {new Date(e.prestation.date_heure).toLocaleDateString()} - {e.note}/5 ⭐
+                  {e.commentaire_client && <p>{e.commentaire_client}</p>}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )
       ))}
     </div>
   );

--- a/packages/frontend/frontoffice/src/components/PrestationCard.jsx
+++ b/packages/frontend/frontoffice/src/components/PrestationCard.jsx
@@ -14,6 +14,11 @@ export default function PrestationCard({ prestation }) {
       </p>
       {/* Badge de statut */}
       <PrestationStatusBadge status={prestation.statut} />
+      {prestation.intervention?.note !== null && (
+        <span className="ml-2 px-2 py-1 rounded bg-green-200 text-green-800 text-sm">
+          Évaluée
+        </span>
+      )}
       {/* Lien vers la page de détail */}
       <Link to={`/prestations/${prestation.id}`} className="text-blue-600 underline">
         Voir détail

--- a/packages/frontend/frontoffice/src/pages/PrestationDetail.jsx
+++ b/packages/frontend/frontoffice/src/pages/PrestationDetail.jsx
@@ -83,6 +83,11 @@ export default function PrestationDetail() {
       <p className="mb-2">{prestation.description}</p>
       <div className="mb-2">
         Statut : <PrestationStatusBadge status={prestation.statut} />
+        {prestation.intervention?.note !== null && (
+          <span className="ml-2 px-2 py-1 rounded bg-green-200 text-green-800 text-sm">
+            Évaluée
+          </span>
+        )}
       </div>
 
       {/* Actions pour le client */}

--- a/packages/frontend/frontoffice/src/pages/ProfilPrestataire.jsx
+++ b/packages/frontend/frontoffice/src/pages/ProfilPrestataire.jsx
@@ -5,6 +5,7 @@ import api from "../services/api";
 export default function ProfilPrestataire() {
   const { user, token } = useAuth();
   const [prestataire, setPrestataire] = useState(null);
+  const [evaluations, setEvaluations] = useState([]);
   const [error, setError] = useState("");
 
   useEffect(() => {
@@ -14,6 +15,19 @@ export default function ProfilPrestataire() {
       .then((res) => setPrestataire(res.data))
       .catch(() => setError("Erreur de chargement"));
   }, [user, token]);
+
+  useEffect(() => {
+    if (!token || !user) return;
+    api
+      .get("/prestations", { headers: { Authorization: `Bearer ${token}` } })
+      .then((res) => {
+        const evals = res.data.filter(
+          (p) => p.prestataire_id === prestataire?.id && p.statut === "terminée" && p.intervention?.note !== null
+        );
+        setEvaluations(evals);
+      })
+      .catch(() => {});
+  }, [token, user, prestataire]);
 
   if (error) return <p className="text-red-600 p-4">{error}</p>;
   if (!prestataire) return <p className="p-4">Chargement...</p>;
@@ -35,6 +49,25 @@ export default function ProfilPrestataire() {
         <p className="text-red-600">
           Motif : {prestataire.motif_refus}
         </p>
+      )}
+      {evaluations.length > 0 && (
+        <div className="mt-6">
+          <h3 className="text-lg font-semibold mb-2">Mes évaluations</h3>
+          <ul className="space-y-2">
+            {evaluations.map((p) => (
+              <li key={p.id} className="border p-2 rounded">
+                <p className="font-medium">{p.type_prestation}</p>
+                <p>
+                  {new Date(p.date_heure).toLocaleDateString()} - {p.intervention.note}
+                  /5 ⭐
+                </p>
+                {p.intervention.commentaire_client && (
+                  <p>{p.intervention.commentaire_client}</p>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- show evaluation badge on prestations
- list evaluations in prestataire profile
- allow admins to view evaluations of prestataires
- notify prestataire by email when evaluated
- track evaluation tasks in checklist

## Testing
- `npm run lint` in `packages/frontend/frontoffice` *(fails: 5 errors, 9 warnings)*
- `npm run lint` in `packages/frontend/backoffice` *(fails: 1 warning)*

------
https://chatgpt.com/codex/tasks/task_e_686d6018e7788331adb5b25bd66dc301