### PR TITLE
Fix admin prestataire action display

### DIFF
--- a/packages/frontend/backoffice/src/pages/admin/AdminPrestataires.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/AdminPrestataires.jsx
@@ -95,12 +95,16 @@ export default function AdminPrestataires() {
                   <button onClick={() => voirEvaluations(p.utilisateur_id)} className="text-indigo-600 hover:underline">
                     Voir évaluations
                   </button>
-                  <button onClick={() => valider(p.utilisateur_id)} className="text-green-600 hover:underline">
-                    Valider
-                  </button>
-                  <button onClick={() => refuser(p.utilisateur_id)} className="text-red-600 hover:underline">
-                    Refuser
-                  </button>
+                  {p.statut === "en_attente" && (
+                    <>
+                      <button onClick={() => valider(p.utilisateur_id)} className="text-green-600 hover:underline">
+                        Valider
+                      </button>
+                      <button onClick={() => refuser(p.utilisateur_id)} className="text-red-600 hover:underline">
+                        Refuser
+                      </button>
+                    </>
+                  )}
                 </td>
               </tr>
             ))}


### PR DESCRIPTION
## Summary
- show validate/refuse buttons only when a provider is awaiting approval

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686d675bdee48331aca9b8770e4f5c5e