### PR TITLE
Fix timezone issue in provider slot selection

### DIFF
--- a/packages/frontend/frontoffice/src/pages/PublierPrestation.jsx
+++ b/packages/frontend/frontoffice/src/pages/PublierPrestation.jsx
@@ -29,10 +29,10 @@ export default function PublierPrestation() {
           headers: { Authorization: `Bearer ${token}` },
         });
         const formatted = res.data.map((s) => {
-          const start = new Date(`${s.date_disponible}T${s.heure_debut}`);
+          const value = `${s.date_disponible}T${s.heure_debut.slice(0, 5)}`;
           return {
             id: s.id,
-            value: start.toISOString().slice(0, 16),
+            value,
             label: `${new Date(s.date_disponible).toLocaleDateString()} \u2013 ${s.heure_debut} \u2192 ${s.heure_fin}`,
           };
         });


### PR DESCRIPTION
## Summary
- keep local date and time when mapping planning slots

## Testing
- `npm run lint` *(fails: 5 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686d7b2674cc833199f97e0aa4648de2