### PR TITLE
Fix evaluated badge logic

### DIFF
--- a/packages/frontend/frontoffice/src/components/PrestationCard.jsx
+++ b/packages/frontend/frontoffice/src/components/PrestationCard.jsx
@@ -14,7 +14,7 @@ export default function PrestationCard({ prestation }) {
       </p>
       {/* Badge de statut */}
       <PrestationStatusBadge status={prestation.statut} />
-      {prestation.intervention?.note !== null && (
+      {prestation.intervention && prestation.intervention.note !== null && (
         <span className="ml-2 px-2 py-1 rounded bg-green-200 text-green-800 text-sm">
           Évaluée
         </span>


### PR DESCRIPTION
## Summary
- update PrestationCard to check that intervention exists before showing the "Évaluée" badge

## Testing
- `npm run lint` *(fails: 5 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686d7f47b7e88331b142085ecca31df5