### PR TITLE
Fix prestation detail relations and badge display

### DIFF
--- a/packages/backend/app/Http/Controllers/PrestationController.php
+++ b/packages/backend/app/Http/Controllers/PrestationController.php
@@ -87,7 +87,11 @@ class PrestationController extends Controller
 
     public function show($id)
     {
-        $prestation = Prestation::with(['client', 'prestataire', 'intervention'])->find($id);
+        $prestation = Prestation::with([
+            'client.utilisateur',
+            'prestataire.utilisateur',
+            'intervention',
+        ])->find($id);
 
         if (! $prestation) {
             return response()->json(['message' => 'Prestation introuvable.'], 404);

--- a/packages/frontend/frontoffice/src/pages/PrestationDetail.jsx
+++ b/packages/frontend/frontoffice/src/pages/PrestationDetail.jsx
@@ -83,7 +83,7 @@ export default function PrestationDetail() {
       <p className="mb-2">{prestation.description}</p>
       <div className="mb-2">
         Statut : <PrestationStatusBadge status={prestation.statut} />
-        {prestation.intervention?.note !== null && (
+        {prestation.intervention && prestation.intervention.note !== null && (
           <span className="ml-2 px-2 py-1 rounded bg-green-200 text-green-800 text-sm">
             Évaluée
           </span>


### PR DESCRIPTION
## Summary
- load user info in `PrestationController@show`
- show "Évaluée" badge only when an intervention exists

## Testing
- `php artisan test --parallel --max-batch-size=1` *(fails: php not found)*
- `npm test` in `packages/frontend/frontoffice` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_686e275f901c8331a6804cce5751fd09