### PR TITLE
Fix client validation on final retrieval

### DIFF
--- a/packages/backend/app/Http/Controllers/EtapeLivraisonController.php
+++ b/packages/backend/app/Http/Controllers/EtapeLivraisonController.php
@@ -133,10 +133,13 @@ class EtapeLivraisonController extends Controller
             }
         }
 
-        if ($request->type === 'retrait' && $user->id !== $etape->livreur_id) {
-            return response()->json([
-                'message' => 'Accès interdit pour valider ce code.'
-            ], 403);
+        if ($request->type === 'retrait') {
+            if ($etape->est_client && $user->id !== $annonce->id_client) {
+                return response()->json(['message' => 'Accès interdit pour valider ce code.'], 403);
+            }
+            if (! $etape->est_client && $user->id !== $etape->livreur_id) {
+                return response()->json(['message' => 'Accès interdit pour valider ce code.'], 403);
+            }
         }
 
         if ($user->role === 'commercant' && $annonce->id_commercant !== $user->id) {


### PR DESCRIPTION
## Summary
- ensure the last retrieval step can only be validated by the client

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686e5f4fba1083319ec458cd7b9328b5