### PR TITLE
Fix Stripe payment flow

### DIFF
--- a/packages/backend/app/Http/Controllers/AnnonceController.php
+++ b/packages/backend/app/Http/Controllers/AnnonceController.php
@@ -513,7 +513,7 @@ class AnnonceController extends Controller
             });
         }
 
-        return redirect(rtrim(env('FRONTEND_URL', ''), '/') . '/paiement/success');
+        return response()->json(['message' => 'Paiement enregistré avec succès.']);
     }
 
 }

--- a/packages/backend/database/migrations/2025_09_01_000000_fix_paiements_columns.php
+++ b/packages/backend/database/migrations/2025_09_01_000000_fix_paiements_columns.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('paiements', function (Blueprint $table) {
+            if (!Schema::hasColumn('paiements', 'annonce_id')) {
+                $table->unsignedBigInteger('annonce_id')->nullable()->after('commande_id');
+                $table->foreign('annonce_id')->references('id')->on('annonces')->onDelete('cascade');
+            }
+            if (!Schema::hasColumn('paiements', 'statut')) {
+                $table->enum('statut', ['valide', 'en_attente', 'annule'])->default('valide')->after('reference');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('paiements', function (Blueprint $table) {
+            if (Schema::hasColumn('paiements', 'annonce_id')) {
+                $table->dropForeign(['annonce_id']);
+                $table->dropColumn('annonce_id');
+            }
+            if (Schema::hasColumn('paiements', 'statut')) {
+                $table->dropColumn('statut');
+            }
+        });
+    }
+};

--- a/packages/frontend/frontoffice/src/pages/PaiementSuccess.jsx
+++ b/packages/frontend/frontoffice/src/pages/PaiementSuccess.jsx
@@ -35,16 +35,18 @@ export default function PaiementSuccess() {
 
     const finalize = async () => {
       try {
+        let paiementOk = true;
         if (annonceId && sessionId) {
-            try {
-                await api.get(`/annonces/${annonceId}/paiement-callback`, {
-                    params: { session_id: sessionId },
-                    headers: { Authorization: `Bearer ${token}` },
-                });
-            } catch (err) {
-                console.error("Erreur callback paiement :", err);
-                setMessage("Erreur lors de la confirmation du paiement.");
-            }
+          try {
+            await api.get(`/annonces/${annonceId}/paiement-callback`, {
+              params: { session_id: sessionId },
+              headers: { Authorization: `Bearer ${token}` },
+            });
+          } catch (err) {
+            console.error("Erreur callback paiement :", err);
+            setMessage("\u274C Une erreur est survenue. Paiement non valid\u00e9.");
+            paiementOk = false;
+          }
         }
         if (context === "prestation_reserver" && prestationId && sessionId) {
           try {
@@ -57,6 +59,8 @@ export default function PaiementSuccess() {
             setMessage("Erreur lors de la réservation de la prestation.");
           }
         }
+
+        if (!paiementOk) return;
 
         if (context === "reserver" && annonceId && entrepotId) {
           await api.post(
@@ -91,7 +95,9 @@ export default function PaiementSuccess() {
         } else if (context === "payer" && annonceId) {
           localStorage.removeItem("payerAnnonceId");
           localStorage.removeItem("paymentContext");
-          setMessage("Annonce payée !");
+          if (paiementOk) {
+            setMessage("Annonce payée !");
+          }
         } else {
           setMessage("Paiement confirmé.");
         }


### PR DESCRIPTION
## Summary
- ensure paiement table has `annonce_id` and `statut` columns
- return JSON after `paiementCallback` instead of redirecting
- in the frontend success page, stop showing success message if callback fails

## Testing
- `npm install` in `packages/frontend/frontoffice`
- `npm run lint` *(fails: no-unused-vars etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686e62813ff48331bf22b6dd38ee4d30