### PR TITLE
Add admin interface for validating deliverers

### DIFF
--- a/packages/backend/app/Http/Controllers/LivreurValidationController.php
+++ b/packages/backend/app/Http/Controllers/LivreurValidationController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Livreur;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class LivreurValidationController extends Controller
+{
+    public function index()
+    {
+        $user = Auth::user();
+        if ($user->role !== 'admin') {
+            return response()->json(['message' => 'Accès interdit.'], 403);
+        }
+
+        $livreurs = Livreur::with('utilisateur')
+            ->where('valide', false)
+            ->get();
+
+        return response()->json($livreurs);
+    }
+
+    public function valider($id)
+    {
+        $user = Auth::user();
+        if ($user->role !== 'admin') {
+            return response()->json(['message' => 'Accès interdit.'], 403);
+        }
+
+        $livreur = Livreur::where('utilisateur_id', $id)->first();
+        if (! $livreur) {
+            return response()->json(['message' => 'Livreur introuvable.'], 404);
+        }
+
+        $livreur->valide = true;
+        $livreur->save();
+
+        return response()->json(['message' => 'Livreur validé.']);
+    }
+
+    public function refuser($id)
+    {
+        $user = Auth::user();
+        if ($user->role !== 'admin') {
+            return response()->json(['message' => 'Accès interdit.'], 403);
+        }
+
+        $livreur = Livreur::where('utilisateur_id', $id)->first();
+        if (! $livreur) {
+            return response()->json(['message' => 'Livreur introuvable.'], 404);
+        }
+
+        $livreur->valide = false;
+        $livreur->save();
+
+        return response()->json(['message' => 'Livreur refusé.']);
+    }
+}

--- a/packages/backend/routes/api.php
+++ b/packages/backend/routes/api.php
@@ -26,6 +26,7 @@ use App\Http\Controllers\PlanningPrestataireController;
 use App\Http\Controllers\InterventionController;
 use App\Http\Controllers\FacturePrestataireController;
 use App\Http\Controllers\PrestataireValidationController;
+use App\Http\Controllers\LivreurValidationController;
 use App\Http\Controllers\StatAdminController;
 use App\Http\Controllers\Api\EmailVerificationController;
 use Laravel\Fortify\Http\Controllers\EmailVerificationNotificationController;
@@ -77,6 +78,11 @@ Route::middleware(['auth:sanctum', 'role:admin'])->group(function () {
     // Validation prestataires
     Route::patch('/prestataires/{id}/valider', [PrestataireValidationController::class, 'valider']);
     Route::patch('/prestataires/{id}/refuser', [PrestataireValidationController::class, 'refuser']);
+
+    // Validation livreurs
+    Route::get('/admin/livreurs', [LivreurValidationController::class, 'index']);
+    Route::post('/admin/livreurs/{id}/valider', [LivreurValidationController::class, 'valider']);
+    Route::post('/admin/livreurs/{id}/refuser', [LivreurValidationController::class, 'refuser']);
 
     // Assignation d'un prestataire à une prestation
     Route::patch('/prestations/{id}/assigner', [PrestationController::class, 'assigner']);

--- a/packages/frontend/backoffice/src/components/Navbar.jsx
+++ b/packages/frontend/backoffice/src/components/Navbar.jsx
@@ -46,6 +46,10 @@ export default function Navbar() {
               Prestataires
             </Link>
 
+            <Link to="/admin/livreurs" className="hover:text-gray-300 transition">
+              Livreurs
+            </Link>
+
             <Link to="/admin/factures-prestataires" className="hover:text-gray-300 transition">
               Factures Prestataires
             </Link>

--- a/packages/frontend/backoffice/src/pages/admin/AdminLivreur.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/AdminLivreur.jsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from "react";
+import api from "../../services/api";
+
+export default function AdminLivreur() {
+  const [livreurs, setLivreurs] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchLivreurs();
+  }, []);
+
+  async function fetchLivreurs() {
+    try {
+      const res = await api.get("/admin/livreurs");
+      setLivreurs(res.data);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const valider = async (id) => {
+    if (!window.confirm("Valider ce livreur ?")) return;
+    try {
+      await api.post(`/admin/livreurs/${id}/valider`);
+      fetchLivreurs();
+    } catch (err) {
+      alert(err.response?.data?.message || "Erreur de validation");
+    }
+  };
+
+  const refuser = async (id) => {
+    if (!window.confirm("Refuser ce livreur ?")) return;
+    try {
+      await api.post(`/admin/livreurs/${id}/refuser`);
+      fetchLivreurs();
+    } catch (err) {
+      alert(err.response?.data?.message || "Erreur de refus");
+    }
+  };
+
+  if (loading) return <div className="p-4">Chargement...</div>;
+
+  return (
+    <div className="p-6 space-y-6">
+      <h1 className="text-2xl font-bold">Livreurs</h1>
+      <div className="overflow-x-auto">
+        <table className="min-w-full bg-white rounded shadow">
+          <thead>
+            <tr className="bg-gray-100 text-left text-sm uppercase text-gray-600">
+              <th className="p-3">Nom</th>
+              <th className="p-3">Email</th>
+              <th className="p-3">Valide</th>
+              <th className="p-3">Documents</th>
+              <th className="p-3">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {livreurs.map((l) => (
+              <tr key={l.id} className="border-b hover:bg-gray-50 align-top">
+                <td className="p-3">{l.utilisateur?.prenom} {l.utilisateur?.nom}</td>
+                <td className="p-3">{l.utilisateur?.email}</td>
+                <td className="p-3">{l.valide ? "Oui" : "Non"}</td>
+                <td className="p-3 space-y-1">
+                  {l.piece_identite_document && (
+                    <a
+                      href={`/storage/${l.piece_identite_document}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-blue-600 underline block"
+                    >
+                      Pièce d'identité
+                    </a>
+                  )}
+                  {l.permis_conduire_document && (
+                    <a
+                      href={`/storage/${l.permis_conduire_document}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-blue-600 underline block"
+                    >
+                      Permis de conduire
+                    </a>
+                  )}
+                </td>
+                <td className="p-3 space-x-2">
+                  {!l.valide && (
+                    <>
+                      <button
+                        onClick={() => valider(l.utilisateur_id)}
+                        className="text-green-600 hover:underline"
+                      >
+                        Valider
+                      </button>
+                      <button
+                        onClick={() => refuser(l.utilisateur_id)}
+                        className="text-red-600 hover:underline"
+                      >
+                        Refuser
+                      </button>
+                    </>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/backoffice/src/routes/AdminRoutes.jsx
+++ b/packages/frontend/backoffice/src/routes/AdminRoutes.jsx
@@ -10,6 +10,7 @@ import AnnoncesList from "../pages/admin/AnnoncesList";
 import EntrepotsList from "../pages/admin/EntrepotsList";
 import PrestationList from "../pages/admin/PrestationList";
 import AdminPrestataires from "../pages/admin/AdminPrestataires";
+import AdminLivreur from "../pages/admin/AdminLivreur";
 import AdminFactures from "../pages/admin/AdminFactures";
 import PaiementsList from "../pages/admin/PaiementsList";
 
@@ -27,6 +28,7 @@ export default function AdminRoutes() {
         <Route path="entrepots" element={<EntrepotsList />} />
         <Route path="prestations" element={<PrestationList />} />
         <Route path="prestataires" element={<AdminPrestataires />} />
+        <Route path="livreurs" element={<AdminLivreur />} />
         <Route path="factures-prestataires" element={<AdminFactures />} />
         <Route path="paiements" element={<PaiementsList />} />
       </Route>


### PR DESCRIPTION
## Summary
- create `LivreurValidationController` for admin validation of deliverers
- expose admin routes `/admin/livreurs` for listing/validating/refusing
- add `AdminLivreur` page to backoffice
- wire new route and navbar link

## Testing
- `npm test` (fails: Missing script)
- `vendor/bin/phpunit` (fails: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_686e756c0b6c83318548edfeb266544e