### PR TITLE
Gestion justificatifs prestataire

### DIFF
--- a/packages/backend/app/Http/Controllers/JustificatifController.php
+++ b/packages/backend/app/Http/Controllers/JustificatifController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\JustificatifPrestataire;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+
+class JustificatifController extends Controller
+{
+    public function index()
+    {
+        $user = Auth::user();
+        $prestataire = $user->prestataire;
+
+        if (! $prestataire) {
+            return response()->json([], 404);
+        }
+
+        return response()->json($prestataire->justificatifs);
+    }
+
+    public function store(Request $request)
+    {
+        $user = Auth::user();
+        $prestataire = $user->prestataire;
+
+        if (! $prestataire) {
+            return response()->json(['message' => 'Accès interdit.'], 403);
+        }
+
+        $request->validate([
+            'fichier' => 'required|file|mimes:pdf,jpg,jpeg,png|max:2048',
+            'type_document' => 'nullable|string',
+        ]);
+
+        $path = $request->file('fichier')->store(
+            "justificatifs/prestataires/{$prestataire->id}",
+            'public'
+        );
+
+        $justificatif = JustificatifPrestataire::create([
+            'prestataire_id' => $prestataire->id,
+            'chemin' => $path,
+            'type' => $request->input('type_document'),
+            'statut' => 'en_attente',
+        ]);
+
+        return response()->json($justificatif, 201);
+    }
+
+    public function destroy($id)
+    {
+        $user = Auth::user();
+        $prestataire = $user->prestataire;
+        $justificatif = JustificatifPrestataire::find($id);
+
+        if (! $prestataire || ! $justificatif || $justificatif->prestataire_id !== $prestataire->id) {
+            return response()->json(['message' => 'Accès interdit.'], 403);
+        }
+
+        if ($justificatif->statut !== 'en_attente') {
+            return response()->json(['message' => 'Impossible de supprimer ce document.'], 422);
+        }
+
+        Storage::disk('public')->delete($justificatif->chemin);
+        $justificatif->delete();
+
+        return response()->json(['message' => 'Document supprimé.']);
+    }
+}

--- a/packages/backend/app/Http/Controllers/PrestataireValidationController.php
+++ b/packages/backend/app/Http/Controllers/PrestataireValidationController.php
@@ -37,7 +37,10 @@ class PrestataireValidationController extends Controller
         ]);
 
         $prestataire = $user->prestataire;
-        $path = $request->file('fichier')->store('justificatifs', 'public');
+        $path = $request->file('fichier')->store(
+            "justificatifs/prestataires/{$prestataire->id}",
+            'public'
+        );
 
         $justificatif = JustificatifPrestataire::create([
             'prestataire_id' => $prestataire->id,

--- a/packages/backend/app/Models/JustificatifPrestataire.php
+++ b/packages/backend/app/Models/JustificatifPrestataire.php
@@ -15,6 +15,7 @@ class JustificatifPrestataire extends Model
         'prestataire_id',
         'chemin',
         'type',
+        'statut',
     ];
 
     public function prestataire()

--- a/packages/backend/database/migrations/2025_09_05_000001_add_statut_to_justificatifs_prestataires_table.php
+++ b/packages/backend/database/migrations/2025_09_05_000001_add_statut_to_justificatifs_prestataires_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('justificatifs_prestataires', function (Blueprint $table) {
+            $table->string('statut')->default('en_attente')->after('type');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('justificatifs_prestataires', function (Blueprint $table) {
+            $table->dropColumn('statut');
+        });
+    }
+};

--- a/packages/backend/routes/api.php
+++ b/packages/backend/routes/api.php
@@ -27,6 +27,7 @@ use App\Http\Controllers\InterventionController;
 use App\Http\Controllers\FacturePrestataireController;
 use App\Http\Controllers\PrestataireValidationController;
 use App\Http\Controllers\LivreurValidationController;
+use App\Http\Controllers\JustificatifController;
 use App\Http\Controllers\StatAdminController;
 use App\Http\Controllers\Api\EmailVerificationController;
 use Laravel\Fortify\Http\Controllers\EmailVerificationNotificationController;
@@ -129,6 +130,10 @@ Route::middleware(['auth:sanctum', 'role:admin,prestataire'])->group(function ()
     Route::post('/prestations', [PrestationController::class, 'store'])->middleware('prestataire.valide');
     Route::post('/prestataires/{id}/justificatifs', [PrestataireValidationController::class, 'store']);
     Route::get('/prestataires/{id}/justificatifs', [PrestataireValidationController::class, 'index']);
+
+    Route::get('/prestataires/justificatifs', [JustificatifController::class, 'index']);
+    Route::post('/prestataires/justificatifs', [JustificatifController::class, 'store']);
+    Route::delete('/prestataires/justificatifs/{id}', [JustificatifController::class, 'destroy']);
 });
 
 // Routes accessibles à tout utilisateur connecté

--- a/packages/frontend/frontoffice/src/pages/ProfilPrestataire.jsx
+++ b/packages/frontend/frontoffice/src/pages/ProfilPrestataire.jsx
@@ -6,6 +6,10 @@ export default function ProfilPrestataire() {
   const { user, token } = useAuth();
   const [prestataire, setPrestataire] = useState(null);
   const [evaluations, setEvaluations] = useState([]);
+  const [justificatifs, setJustificatifs] = useState([]);
+  const [newFile, setNewFile] = useState(null);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState("");
   const [error, setError] = useState("");
 
   useEffect(() => {
@@ -32,6 +36,49 @@ export default function ProfilPrestataire() {
       })
       .catch(() => {});
   }, [token, user, prestataire]);
+
+  useEffect(() => {
+    if (!token) return;
+    api
+      .get("/prestataires/justificatifs", {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      .then((res) => setJustificatifs(res.data))
+      .catch(() => setUploadError("Erreur chargement des justificatifs"));
+  }, [token]);
+
+  const handleUpload = async () => {
+    if (!newFile) return;
+    setUploading(true);
+    const data = new FormData();
+    data.append("fichier", newFile);
+    try {
+      const res = await api.post("/prestataires/justificatifs", data, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "multipart/form-data",
+        },
+      });
+      setJustificatifs((prev) => [...prev, res.data]);
+      setNewFile(null);
+  } catch {
+      setUploadError("Erreur lors de l'envoi du fichier");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!window.confirm("Supprimer ce document ?")) return;
+    try {
+      await api.delete(`/prestataires/justificatifs/${id}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setJustificatifs((prev) => prev.filter((j) => j.id !== id));
+  } catch {
+      alert("Suppression impossible");
+    }
+  };
 
   if (error) return <p className="text-red-600 p-4">{error}</p>;
   if (!prestataire) return <p className="p-4">Chargement...</p>;
@@ -73,6 +120,43 @@ export default function ProfilPrestataire() {
           </ul>
         </div>
       )}
+
+      <div className="mt-6">
+        <h3 className="text-lg font-semibold mb-2">Mes justificatifs</h3>
+        {uploadError && <p className="text-red-600">{uploadError}</p>}
+        <ul className="space-y-2 mb-4">
+          {justificatifs.map((j) => (
+            <li
+              key={j.id}
+              className="border p-2 rounded flex justify-between items-center"
+            >
+              <span>
+                {j.chemin.split("/").pop()} - {j.statut || "en attente"}
+              </span>
+              {j.statut === "en_attente" && (
+                <button
+                  onClick={() => handleDelete(j.id)}
+                  className="text-sm text-red-600 hover:underline"
+                >
+                  Supprimer
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+        <input
+          type="file"
+          onChange={(e) => setNewFile(e.target.files[0])}
+          className="mb-2"
+        />
+        <button
+          onClick={handleUpload}
+          disabled={uploading}
+          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+        >
+          {uploading ? "Envoi..." : "Ajouter"}
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a controller to handle justificatifs
- support statut column for justificatifs
- expose new justificatif routes
- allow uploading from PrestataireValidationController to proper folder
- display and manage justificatifs in ProfilPrestataire

## Testing
- `npm install`
- `npm run lint` *(fails: 5 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686eaa6c2cec83318687878f845a482d