### PR TITLE
Handle refused delivery profiles

### DIFF
--- a/packages/backend/app/Http/Controllers/JustificatifLivreurController.php
+++ b/packages/backend/app/Http/Controllers/JustificatifLivreurController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Notification;
+use App\Models\Utilisateur;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+
+class JustificatifLivreurController extends Controller
+{
+    public function store(Request $request)
+    {
+        $user = Auth::user();
+        if ($user->role !== 'livreur') {
+            return response()->json(['message' => 'Accès interdit.'], 403);
+        }
+
+        $validated = $request->validate([
+            'piece_identite_document' => 'nullable|file|mimes:jpg,png,pdf|max:2048',
+            'permis_conduire_document' => 'nullable|file|mimes:jpg,png,pdf|max:2048',
+        ]);
+
+        $livreur = $user->livreur;
+
+        if (isset($validated['piece_identite_document'])) {
+            $path = $request->file('piece_identite_document')->store('documents/livreurs', 'public');
+            if ($livreur->piece_identite_document) {
+                Storage::disk('public')->delete($livreur->piece_identite_document);
+            }
+            $livreur->piece_identite_document = $path;
+        }
+
+        if (isset($validated['permis_conduire_document'])) {
+            $path = $request->file('permis_conduire_document')->store('documents/livreurs', 'public');
+            if ($livreur->permis_conduire_document) {
+                Storage::disk('public')->delete($livreur->permis_conduire_document);
+            }
+            $livreur->permis_conduire_document = $path;
+        }
+
+        if ($livreur->statut === 'refuse') {
+            $livreur->statut = 'en_attente';
+            $livreur->motif_refus = null;
+        }
+
+        $livreur->save();
+
+        $admin = Utilisateur::where('role', 'admin')->first();
+        if ($admin) {
+            Notification::create([
+                'utilisateur_id' => $admin->id,
+                'titre' => 'Nouveau justificatif livreur',
+                'contenu' => "Le livreur {$user->prenom} {$user->nom} a soumis de nouveaux documents.",
+            ]);
+        }
+
+        return response()->json(['message' => 'Documents enregistrés.', 'livreur' => $livreur]);
+    }
+}

--- a/packages/backend/app/Http/Controllers/LivreurValidationController.php
+++ b/packages/backend/app/Http/Controllers/LivreurValidationController.php
@@ -35,12 +35,14 @@ class LivreurValidationController extends Controller
         }
 
         $livreur->valide = true;
+        $livreur->statut = 'valide';
+        $livreur->motif_refus = null;
         $livreur->save();
 
         return response()->json(['message' => 'Livreur validé.']);
     }
 
-    public function refuser($id)
+    public function refuser(Request $request, $id)
     {
         $user = Auth::user();
         if ($user->role !== 'admin') {
@@ -52,7 +54,13 @@ class LivreurValidationController extends Controller
             return response()->json(['message' => 'Livreur introuvable.'], 404);
         }
 
+        $validated = $request->validate([
+            'motif_refus' => 'nullable|string',
+        ]);
+
         $livreur->valide = false;
+        $livreur->statut = 'refuse';
+        $livreur->motif_refus = $validated['motif_refus'] ?? null;
         $livreur->save();
 
         return response()->json(['message' => 'Livreur refusé.']);

--- a/packages/backend/app/Http/Kernel.php
+++ b/packages/backend/app/Http/Kernel.php
@@ -46,5 +46,6 @@ class Kernel extends HttpKernel
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         'role' => \App\Http\Middleware\CheckRole::class,
         'prestataire.valide' => \App\Http\Middleware\PrestataireValide::class,
+        'livreur.valide' => \App\Http\Middleware\LivreurValide::class,
     ];
 }

--- a/packages/backend/app/Http/Middleware/LivreurValide.php
+++ b/packages/backend/app/Http/Middleware/LivreurValide.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class LivreurValide
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $user = Auth::user();
+        if ($user->role !== 'livreur' || ($user->livreur->statut ?? '') !== 'valide') {
+            return response()->json(['message' => 'Livreur non valide.'], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/packages/backend/app/Models/Livreur.php
+++ b/packages/backend/app/Models/Livreur.php
@@ -14,6 +14,10 @@ class Livreur extends Model
         'piece_identite',
         'permis_conduire',
         'valide',
+        'statut',
+        'motif_refus',
+        'piece_identite_document',
+        'permis_conduire_document',
     ];
 
     public function utilisateur()

--- a/packages/backend/database/migrations/2025_09_06_000002_add_statut_to_livreurs_table.php
+++ b/packages/backend/database/migrations/2025_09_06_000002_add_statut_to_livreurs_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('livreurs', function (Blueprint $table) {
+            $table->string('statut')->default('en_attente');
+            $table->text('motif_refus')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('livreurs', function (Blueprint $table) {
+            $table->dropColumn(['statut', 'motif_refus']);
+        });
+    }
+};

--- a/packages/backend/routes/api.php
+++ b/packages/backend/routes/api.php
@@ -28,6 +28,7 @@ use App\Http\Controllers\FacturePrestataireController;
 use App\Http\Controllers\PrestataireValidationController;
 use App\Http\Controllers\LivreurValidationController;
 use App\Http\Controllers\JustificatifController;
+use App\Http\Controllers\JustificatifLivreurController;
 use App\Http\Controllers\StatAdminController;
 use App\Http\Controllers\Api\EmailVerificationController;
 use Laravel\Fortify\Http\Controllers\EmailVerificationNotificationController;
@@ -110,11 +111,15 @@ Route::middleware(['auth:sanctum', 'role:admin,livreur'])->group(function () {
     Route::patch('/colis/{id}/box', [ColisController::class, 'affecterBox']);
     Route::get('/livreurs/{id}', [LivreurController::class, 'show']);
     Route::patch('/livreurs/{id}', [LivreurController::class, 'update']);
-    Route::get('/annonces-disponibles', [AnnonceController::class, 'annoncesDisponibles']);
-    Route::post('/annonces/{id}/accepter', [AnnonceController::class, 'accepterAnnonce']);
-    Route::get('/mes-trajets', [TrajetLivreurController::class, 'index']);
-    Route::post('/mes-trajets', [TrajetLivreurController::class, 'store']);
-    Route::delete('/mes-trajets/{id}', [TrajetLivreurController::class, 'destroy']);
+    Route::post('/livreurs/justificatifs', [JustificatifLivreurController::class, 'store']);
+
+    Route::middleware('livreur.valide')->group(function () {
+        Route::get('/annonces-disponibles', [AnnonceController::class, 'annoncesDisponibles']);
+        Route::post('/annonces/{id}/accepter', [AnnonceController::class, 'accepterAnnonce']);
+        Route::get('/mes-trajets', [TrajetLivreurController::class, 'index']);
+        Route::post('/mes-trajets', [TrajetLivreurController::class, 'store']);
+        Route::delete('/mes-trajets/{id}', [TrajetLivreurController::class, 'destroy']);
+    });
 });
 
 // COMMERCANT uniquement

--- a/packages/frontend/frontoffice/src/pages/MesTrajets.jsx
+++ b/packages/frontend/frontoffice/src/pages/MesTrajets.jsx
@@ -3,8 +3,9 @@ import api from "../services/api";
 import { useAuth } from "../context/AuthContext";
 
 export default function MesTrajets() {
-  const { token } = useAuth();
+  const { token, user } = useAuth();
   const [trajets, setTrajets] = useState([]);
+  const [livreur, setLivreur] = useState(null);
   const [entrepots, setEntrepots] = useState([]);
   const [form, setForm] = useState({
     entrepot_depart_id: "",
@@ -15,7 +16,17 @@ export default function MesTrajets() {
 
   useEffect(() => {
     fetchEntrepots();
-    fetchTrajets();
+    if (user) {
+      api
+        .get(`/livreurs/${user.id}`, { headers: { Authorization: `Bearer ${token}` } })
+        .then((res) => {
+          setLivreur(res.data);
+          if (res.data.statut === "valide") {
+            fetchTrajets();
+          }
+        })
+        .catch(() => setLivreur(null));
+    }
   }, []);
 
   const fetchEntrepots = async () => {
@@ -80,6 +91,14 @@ export default function MesTrajets() {
       console.error("Erreur suppression:", err);
     }
   };
+
+  if (livreur && livreur.statut !== "valide") {
+    return (
+      <p className="p-4 text-red-600">
+        ⛔ Vous ne pouvez pas accéder à cette fonctionnalité tant que votre profil n’est pas validé.
+      </p>
+    );
+  }
 
   return (
     <div className="max-w-3xl mx-auto mt-10 p-6 bg-white shadow rounded">

--- a/packages/frontend/frontoffice/src/pages/ProfilLivreur.jsx
+++ b/packages/frontend/frontoffice/src/pages/ProfilLivreur.jsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+import { useAuth } from "../context/AuthContext";
+import api from "../services/api";
+
+export default function ProfilLivreur() {
+  const { user, token } = useAuth();
+  const [livreur, setLivreur] = useState(null);
+  const [files, setFiles] = useState({ identite: null, permis: null });
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!user) return;
+    api
+      .get(`/livreurs/${user.id}`, { headers: { Authorization: `Bearer ${token}` } })
+      .then((res) => setLivreur(res.data))
+      .catch(() => setError("Erreur de chargement"));
+  }, [user, token]);
+
+  const statutLabel =
+    livreur?.statut === "valide"
+      ? "Validé"
+      : livreur?.statut === "refuse"
+      ? "Refusé"
+      : "En attente";
+
+  const handleUpload = async () => {
+    if (!files.identite && !files.permis) return;
+    const data = new FormData();
+    if (files.identite) data.append("piece_identite_document", files.identite);
+    if (files.permis) data.append("permis_conduire_document", files.permis);
+    setUploading(true);
+    try {
+      const res = await api.post("/livreurs/justificatifs", data, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "multipart/form-data",
+        },
+      });
+      setLivreur(res.data.livreur);
+      setFiles({ identite: null, permis: null });
+    } catch {
+      setError("Erreur lors de l'envoi du fichier");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  if (error) return <p className="text-red-600 p-4">{error}</p>;
+  if (!livreur) return <p className="p-4">Chargement...</p>;
+
+  return (
+    <div className="max-w-xl mx-auto mt-10 bg-white p-6 rounded shadow space-y-4">
+      <h2 className="text-2xl font-bold text-center">Mon statut livreur</h2>
+      <p>
+        <strong>Statut :</strong> {statutLabel}
+      </p>
+      {livreur.statut === "refuse" && livreur.motif_refus && (
+        <p className="text-red-600">Motif : {livreur.motif_refus}</p>
+      )}
+      {livreur.statut !== "valide" && (
+        <p className="text-red-600 font-semibold">
+          Votre profil a été refusé. Vous ne pouvez pas livrer tant que votre profil n'est pas validé.
+        </p>
+      )}
+      <div className="mt-6 space-y-2">
+        <h3 className="text-lg font-semibold">Mes justificatifs</h3>
+        <p>
+          Pièce d'identité : {livreur.piece_identite_document ? livreur.piece_identite_document.split("/").pop() : "Aucun"}
+        </p>
+        <p>
+          Permis de conduire : {livreur.permis_conduire_document ? livreur.permis_conduire_document.split("/").pop() : "Aucun"}
+        </p>
+        <input type="file" onChange={(e) => setFiles(f => ({ ...f, identite: e.target.files[0] }))} className="block" />
+        <input type="file" onChange={(e) => setFiles(f => ({ ...f, permis: e.target.files[0] }))} className="block mt-2" />
+        <button
+          onClick={handleUpload}
+          disabled={uploading}
+          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50 mt-2"
+        >
+          {uploading ? "Envoi..." : "Envoyer"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/frontoffice/src/routes/Router.jsx
+++ b/packages/frontend/frontoffice/src/routes/Router.jsx
@@ -24,6 +24,7 @@ import AnnoncesDisponibles from "../pages/AnnoncesDisponibles";
 import MesLivraisons from "../pages/MesLivraisons";
 import Factures from "../pages/Factures";
 import ProfilPrestataire from "../pages/ProfilPrestataire";
+import ProfilLivreur from "../pages/ProfilLivreur";
 import PublierPrestation from "../pages/PublierPrestation";
 import Notifications from "../pages/Notifications";
 import Catalogue from "../pages/Catalogue";
@@ -252,6 +253,17 @@ export default function AppRouter() {
               <PrivateRoute>
                 <RoleRoute role={["prestataire"]}>
                   <ProfilPrestataire />
+                </RoleRoute>
+              </PrivateRoute>
+            }
+          />
+
+          <Route
+            path="/profil-livreur"
+            element={
+              <PrivateRoute>
+                <RoleRoute role={["livreur"]}>
+                  <ProfilLivreur />
                 </RoleRoute>
               </PrivateRoute>
             }


### PR DESCRIPTION
## Summary
- allow Livreurs to reupload documents and notify admin
- enforce `statut` on livraison routes via new middleware
- expose new API endpoints and fields
- add profile page for livreurs with document upload
- block UI actions when livreur account isn't validated

## Testing
- `npm test --silent` *(fails: no tests)*
- `./vendor/bin/phpunit` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eadde1e7083318346b816bb136b8e