### PR TITLE
Remove admin notification features

### DIFF
--- a/packages/backend/app/Http/Controllers/JustificatifLivreurController.php
+++ b/packages/backend/app/Http/Controllers/JustificatifLivreurController.php
@@ -2,8 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Notification;
-use App\Models\Utilisateur;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
@@ -46,15 +44,6 @@ class JustificatifLivreurController extends Controller
         }
 
         $livreur->save();
-
-        $admin = Utilisateur::where('role', 'admin')->first();
-        if ($admin) {
-            Notification::create([
-                'utilisateur_id' => $admin->id,
-                'titre' => 'Nouveau justificatif livreur',
-                'contenu' => "Le livreur {$user->prenom} {$user->nom} a soumis de nouveaux documents.",
-            ]);
-        }
 
         return response()->json(['message' => 'Documents enregistrés.', 'livreur' => $livreur]);
     }

--- a/packages/backend/routes/api.php
+++ b/packages/backend/routes/api.php
@@ -55,8 +55,6 @@ Route::middleware(['auth:sanctum', 'role:admin'])->group(function () {
     Route::post('/utilisateurs', [UtilisateurController::class, 'store']);
     Route::patch('/utilisateurs/{id}', [UtilisateurController::class, 'update']);
 
-    // Notifications
-    Route::post('/notifications', [NotificationController::class, 'store']);
 
     // Entrepôts
     Route::post('/entrepots', [EntrepotController::class, 'store']);


### PR DESCRIPTION
## Summary
- drop admin notification creation in `JustificatifLivreurController`
- remove route allowing admin to create notifications

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686f6274adf483318c78dc7cf9424092