### PR TITLE
Amélioration flux validation/refus

### DIFF
--- a/packages/backend/app/Http/Controllers/JustificatifController.php
+++ b/packages/backend/app/Http/Controllers/JustificatifController.php
@@ -47,6 +47,12 @@ class JustificatifController extends Controller
             'statut' => 'en_attente',
         ]);
 
+        if ($prestataire->statut === 'refuse') {
+            $prestataire->statut = 'en_attente';
+            $prestataire->motif_refus = null;
+            $prestataire->save();
+        }
+
         return response()->json($justificatif, 201);
     }
 

--- a/packages/frontend/backoffice/src/pages/admin/AdminLivreur.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/AdminLivreur.jsx
@@ -31,9 +31,10 @@ export default function AdminLivreur() {
   };
 
   const refuser = async (id) => {
-    if (!window.confirm("Refuser ce livreur ?")) return;
+    const motif = prompt("Motif du refus ?", "");
+    if (motif === null) return;
     try {
-      await api.post(`/admin/livreurs/${id}/refuser`);
+      await api.post(`/admin/livreurs/${id}/refuser`, { motif_refus: motif });
       fetchLivreurs();
     } catch (err) {
       alert(err.response?.data?.message || "Erreur de refus");
@@ -53,6 +54,7 @@ export default function AdminLivreur() {
               <th className="p-3">Email</th>
               <th className="p-3">Valide</th>
               <th className="p-3">Documents</th>
+              <th className="p-3">Motif de refus</th>
               <th className="p-3">Actions</th>
             </tr>
           </thead>
@@ -84,6 +86,7 @@ export default function AdminLivreur() {
                     </a>
                   )}
                 </td>
+                <td className="p-3 text-sm">{l.motif_refus || ""}</td>
                 <td className="p-3 space-x-2">
                   {!l.valide && (
                     <>

--- a/packages/frontend/backoffice/src/pages/admin/AdminPrestataires.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/AdminPrestataires.jsx
@@ -77,6 +77,7 @@ export default function AdminPrestataires() {
               <th className="p-3">Nom</th>
               <th className="p-3">Email</th>
               <th className="p-3">Statut</th>
+              <th className="p-3">Motif de refus</th>
               <th className="p-3">Inscription</th>
               <th className="p-3">Actions</th>
             </tr>
@@ -87,6 +88,7 @@ export default function AdminPrestataires() {
                 <td className="p-3">{p.utilisateur?.prenom} {p.utilisateur?.nom}</td>
                 <td className="p-3">{p.utilisateur?.email}</td>
                 <td className="p-3 capitalize">{p.statut}</td>
+                <td className="p-3 text-sm">{p.motif_refus || ""}</td>
                 <td className="p-3">{new Date(p.created_at).toLocaleDateString()}</td>
                 <td className="p-3 space-x-2">
                   <button onClick={() => voirJustifs(p.utilisateur_id)} className="text-blue-600 hover:underline">

--- a/packages/frontend/frontoffice/src/pages/Disponibilites.jsx
+++ b/packages/frontend/frontoffice/src/pages/Disponibilites.jsx
@@ -5,13 +5,15 @@ import api from "../services/api";
 import PlanningForm from "../components/PlanningForm";
 
 export default function Disponibilites() {
-  const { token } = useAuth();
+  const { token, user } = useAuth();
 
   const [slots, setSlots] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
   const [message, setMessage] = useState("");
+  const [prestataire, setPrestataire] = useState(null);
+  const [loadingPrestataire, setLoadingPrestataire] = useState(true);
 
   const fetchSlots = async () => {
     setLoading(true);
@@ -27,6 +29,17 @@ export default function Disponibilites() {
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (!user) return;
+    api
+      .get(`/prestataires/${user.id}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      .then((res) => setPrestataire(res.data))
+      .catch(() => setPrestataire(null))
+      .finally(() => setLoadingPrestataire(false));
+  }, [user, token]);
 
   useEffect(() => {
     fetchSlots();
@@ -72,6 +85,15 @@ export default function Disponibilites() {
       alert("Erreur lors de la suppression.");
     }
   };
+
+  if (loadingPrestataire) return <p className="p-4">Chargement...</p>;
+  if (prestataire && prestataire.statut !== "valide") {
+    return (
+      <p className="p-4 text-red-600">
+        Vous ne pouvez pas gérer vos disponibilités tant que votre profil n'est pas validé
+      </p>
+    );
+  }
 
   return (
     <div className="max-w-xl mx-auto mt-10 p-6 bg-white shadow rounded">

--- a/packages/frontend/frontoffice/src/pages/ProfilLivreur.jsx
+++ b/packages/frontend/frontoffice/src/pages/ProfilLivreur.jsx
@@ -55,13 +55,13 @@ export default function ProfilLivreur() {
       <p>
         <strong>Statut :</strong> {statutLabel}
       </p>
-      {livreur.statut === "refuse" && livreur.motif_refus && (
-        <p className="text-red-600">Motif : {livreur.motif_refus}</p>
-      )}
-      {livreur.statut !== "valide" && (
+      {livreur.statut === "refuse" && (
         <p className="text-red-600 font-semibold">
-          Votre profil a été refusé. Vous ne pouvez pas livrer tant que votre profil n'est pas validé.
+          {livreur.motif_refus ? `Motif : ${livreur.motif_refus}` : "Votre profil a été refusé."}
         </p>
+      )}
+      {livreur.statut === "en_attente" && (
+        <p className="text-orange-600 font-semibold">Votre profil est en attente de validation.</p>
       )}
       <div className="mt-6 space-y-2">
         <h3 className="text-lg font-semibold">Mes justificatifs</h3>

--- a/packages/frontend/frontoffice/src/pages/ProfilPrestataire.jsx
+++ b/packages/frontend/frontoffice/src/pages/ProfilPrestataire.jsx
@@ -96,10 +96,16 @@ export default function ProfilPrestataire() {
       <p>
         <strong>Statut :</strong> {statutLabel}
       </p>
-      {prestataire.statut === "refuse" && prestataire.motif_refus && (
+      {prestataire.statut === "refuse" && (
         <p className="text-red-600">
-          Motif : {prestataire.motif_refus}
+          {prestataire.motif_refus && (
+            <span>Motif : {prestataire.motif_refus}</span>
+          )}
+          {!prestataire.motif_refus && <span>Votre profil a été refusé.</span>}
         </p>
+      )}
+      {prestataire.statut === "en_attente" && (
+        <p className="text-orange-600">Votre profil est en attente de validation.</p>
       )}
       {evaluations.length > 0 && (
         <div className="mt-6">

--- a/packages/frontend/frontoffice/src/pages/PublierPrestation.jsx
+++ b/packages/frontend/frontoffice/src/pages/PublierPrestation.jsx
@@ -5,7 +5,7 @@ import api from "../services/api";
 import { useNavigate } from "react-router-dom";
 
 export default function PublierPrestation() {
-  const { token } = useAuth();
+  const { token, user } = useAuth();
   const navigate = useNavigate();
 
   const [form, setForm] = useState({
@@ -21,6 +21,19 @@ export default function PublierPrestation() {
   const [success, setSuccess] = useState(false);
   const [slotsDisponibles, setSlotsDisponibles] = useState([]);
   const [error, setError] = useState("");
+  const [prestataire, setPrestataire] = useState(null);
+  const [loadingPrestataire, setLoadingPrestataire] = useState(true);
+
+  useEffect(() => {
+    if (!user) return;
+    api
+      .get(`/prestataires/${user.id}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      .then((res) => setPrestataire(res.data))
+      .catch(() => setPrestataire(null))
+      .finally(() => setLoadingPrestataire(false));
+  }, [user, token]);
 
   useEffect(() => {
     const fetchSlots = async () => {
@@ -87,6 +100,15 @@ export default function PublierPrestation() {
       setLoading(false);
     }
   };
+
+  if (loadingPrestataire) return <p className="p-4">Chargement...</p>;
+  if (prestataire && prestataire.statut !== "valide") {
+    return (
+      <p className="p-4 text-red-600">
+        Vous ne pouvez pas publier tant que votre profil n'est pas validé
+      </p>
+    );
+  }
 
   return (
     <div className="max-w-xl mx-auto mt-10 p-6 bg-white shadow rounded">


### PR DESCRIPTION
## Summary
- ajout de la remise en attente d'un prestataire lors d'un nouvel envoi de justificatif
- enregistrement du motif de refus et affichage dans le backoffice
- affichage explicite du statut et des motifs côté profils utilisateurs
- blocage de la publication et des disponibilités pour les prestataires non validés

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `composer install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f6554ed3c8331911c2b9da1f2fa60