### PR TITLE
Fix refused profiles workflow

### DIFF
--- a/packages/backend/routes/api.php
+++ b/packages/backend/routes/api.php
@@ -204,14 +204,16 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::post('/communications/{id}/lire', [CommunicationController::class, 'markAsRead']);
 
     // Étapes de livraison
-    Route::get('/mes-etapes', [EtapeLivraisonController::class, 'mesEtapes']);
+    Route::middleware('livreur.valide')->group(function () {
+        Route::get('/mes-etapes', [EtapeLivraisonController::class, 'mesEtapes']);
+        Route::post('/valider-code-box', [EtapeLivraisonController::class, 'validerCode']);
+    });
     Route::get('/etapes/{id}', [EtapeLivraisonController::class, 'show']);
     Route::patch('/etapes/{id}/statut', [EtapeLivraisonController::class, 'changerStatut']);
     Route::patch('/etapes/{id}/cloturer', [EtapeLivraisonController::class, 'cloturerEtape']);
     Route::get('/etapes/{id}/suivante', [EtapeLivraisonController::class, 'etapeSuivante']);
 
     // Codes validation box
-    Route::post('/valider-code-box', [EtapeLivraisonController::class, 'validerCode']);
     Route::get('/etapes/{id}/codes', [EtapeLivraisonController::class, 'codes']);
 
     // Livreur
@@ -243,8 +245,10 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::delete('/plannings/{id}', [PlanningPrestataireController::class, 'destroy']);
 
     // InterventionPrestataire
-    Route::get('/interventions', [InterventionController::class, 'index']);
-    Route::post('/interventions', [InterventionController::class, 'store']);
+    Route::middleware('prestataire.valide')->group(function () {
+        Route::get('/interventions', [InterventionController::class, 'index']);
+        Route::post('/interventions', [InterventionController::class, 'store']);
+    });
 
     // FacturePrestataire
     Route::get('/factures-prestataire', [FacturePrestataireController::class, 'mesFactures']);

--- a/packages/frontend/backoffice/src/pages/admin/AdminLivreur.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/AdminLivreur.jsx
@@ -53,6 +53,7 @@ export default function AdminLivreur() {
               <th className="p-3">Nom</th>
               <th className="p-3">Email</th>
               <th className="p-3">Valide</th>
+              <th className="p-3">Statut</th>
               <th className="p-3">Documents</th>
               <th className="p-3">Motif de refus</th>
               <th className="p-3">Actions</th>
@@ -64,6 +65,7 @@ export default function AdminLivreur() {
                 <td className="p-3">{l.utilisateur?.prenom} {l.utilisateur?.nom}</td>
                 <td className="p-3">{l.utilisateur?.email}</td>
                 <td className="p-3">{l.valide ? "Oui" : "Non"}</td>
+                <td className="p-3 capitalize">{l.statut}</td>
                 <td className="p-3 space-y-1">
                   {l.piece_identite_document && (
                     <a

--- a/packages/frontend/frontoffice/src/pages/MesEtapes.jsx
+++ b/packages/frontend/frontoffice/src/pages/MesEtapes.jsx
@@ -4,7 +4,8 @@ import { useAuth } from "../context/AuthContext";
 import { Link, useNavigate } from "react-router-dom";
 
 export default function MesEtapes() {
-  const { token } = useAuth();
+  const { token, user } = useAuth();
+  const livreur = user?.livreur;
   const navigate = useNavigate();
   const [etapes, setEtapes] = useState([]);
   const [toutesEtapes, setToutesEtapes] = useState([]);
@@ -30,6 +31,14 @@ export default function MesEtapes() {
   useEffect(() => {
     fetchEtapes();
   }, [token]);
+
+  if (livreur && livreur.statut !== "valide") {
+    return (
+      <p className="p-4 text-red-600">
+        ⛔️ Vous ne pouvez pas accéder à cette fonctionnalité tant que votre profil n’est pas validé.
+      </p>
+    );
+  }
 
   return (
     <div className="max-w-4xl mx-auto mt-10 p-6 bg-white shadow rounded">

--- a/packages/frontend/frontoffice/src/pages/ProfilPrestataire.jsx
+++ b/packages/frontend/frontoffice/src/pages/ProfilPrestataire.jsx
@@ -60,8 +60,16 @@ export default function ProfilPrestataire() {
         },
       });
       setJustificatifs((prev) => [...prev, res.data]);
+
+      const profil = await api.get(`/prestataires/${user.id}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setPrestataire(profil.data);
+      alert(
+        "\u2705 Vos documents ont bien été reçus. Votre profil repasse en cours de validation."
+      );
       setNewFile(null);
-  } catch {
+    } catch {
       setUploadError("Erreur lors de l'envoi du fichier");
     } finally {
       setUploading(false);


### PR DESCRIPTION
## Summary
- show livreur status in admin list
- sync prestataire status after doc upload and confirm
- protect mes-etapes and code validation routes with livreur middleware
- secure interventions with prestataire middleware
- block refused livreur on MesEtapes page

## Testing
- `npm run lint` in backoffice
- `npm run lint` in frontoffice
- ❌ `php -v` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f6a2d5b108331821b6ca1b051a6ff