### PR TITLE
Add viewer endpoint for livreur justificatifs

### DIFF
--- a/packages/backend/routes/api.php
+++ b/packages/backend/routes/api.php
@@ -109,6 +109,7 @@ Route::middleware(['auth:sanctum', 'role:admin,livreur'])->group(function () {
     Route::patch('/colis/{id}/box', [ColisController::class, 'affecterBox']);
     Route::get('/livreurs/{id}', [LivreurController::class, 'show']);
     Route::patch('/livreurs/{id}', [LivreurController::class, 'update']);
+    Route::get('/livreurs/{id}/justificatifs', [JustificatifLivreurController::class, 'index']);
     Route::post('/livreurs/justificatifs', [JustificatifLivreurController::class, 'store']);
 
     Route::middleware('livreur.valide')->group(function () {

--- a/packages/frontend/frontoffice/src/pages/ProfilLivreur.jsx
+++ b/packages/frontend/frontoffice/src/pages/ProfilLivreur.jsx
@@ -38,6 +38,9 @@ export default function ProfilLivreur() {
         },
       });
       setLivreur(res.data.livreur);
+      alert(
+        "\u2705 Vos documents ont bien été reçus. Votre profil repasse en validation."
+      );
       setFiles({ identite: null, permis: null });
     } catch {
       setError("Erreur lors de l'envoi du fichier");


### PR DESCRIPTION
## Summary
- provide an endpoint to list livreur justificatifs
- show success alert when a livreur uploads justificatifs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686f6e9cc1f483318dcfa8c13cd1097d