### PR TITLE
Fix livreur justificatif routes and upload display

### DIFF
--- a/packages/backend/routes/api.php
+++ b/packages/backend/routes/api.php
@@ -107,9 +107,9 @@ Route::middleware(['auth:sanctum', 'role:admin,client'])->group(function () {
 Route::middleware(['auth:sanctum', 'role:admin,livreur'])->group(function () {
     Route::post('/colis', [ColisController::class, 'store']);
     Route::patch('/colis/{id}/box', [ColisController::class, 'affecterBox']);
-    Route::get('/livreurs/{id}', [LivreurController::class, 'show']);
-    Route::patch('/livreurs/{id}', [LivreurController::class, 'update']);
-    Route::get('/livreurs/{id}/justificatifs', [JustificatifLivreurController::class, 'index']);
+    Route::get('/livreurs/{id}', [LivreurController::class, 'show'])->whereNumber('id');
+    Route::patch('/livreurs/{id}', [LivreurController::class, 'update'])->whereNumber('id');
+    Route::get('/livreurs/{id}/justificatifs', [JustificatifLivreurController::class, 'index'])->whereNumber('id');
     Route::post('/livreurs/justificatifs', [JustificatifLivreurController::class, 'store']);
 
     Route::middleware('livreur.valide')->group(function () {

--- a/packages/frontend/frontoffice/src/pages/ProfilLivreur.jsx
+++ b/packages/frontend/frontoffice/src/pages/ProfilLivreur.jsx
@@ -74,15 +74,31 @@ export default function ProfilLivreur() {
         <p>
           Permis de conduire : {livreur.permis_conduire_document ? livreur.permis_conduire_document.split("/").pop() : "Aucun"}
         </p>
-        <input type="file" onChange={(e) => setFiles(f => ({ ...f, identite: e.target.files[0] }))} className="block" />
-        <input type="file" onChange={(e) => setFiles(f => ({ ...f, permis: e.target.files[0] }))} className="block mt-2" />
-        <button
-          onClick={handleUpload}
-          disabled={uploading}
-          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50 mt-2"
-        >
-          {uploading ? "Envoi..." : "Envoyer"}
-        </button>
+        {livreur.statut === "refuse" && (
+          <>
+            <input
+              type="file"
+              onChange={(e) =>
+                setFiles((f) => ({ ...f, identite: e.target.files[0] }))
+              }
+              className="block"
+            />
+            <input
+              type="file"
+              onChange={(e) =>
+                setFiles((f) => ({ ...f, permis: e.target.files[0] }))
+              }
+              className="block mt-2"
+            />
+            <button
+              onClick={handleUpload}
+              disabled={uploading}
+              className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50 mt-2"
+            >
+              {uploading ? "Envoi..." : "Envoyer"}
+            </button>
+          </>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add `whereNumber('id')` constraints to the livreur routes
- hide upload fields in ProfilLivreur unless the status is `refuse`

## Testing
- `npm run lint` *(fails: 5 errors, 9 warnings)*
- `composer update --lock` *(fails: missing PHP extensions)*

------
https://chatgpt.com/codex/tasks/task_e_686ff4f97e108331aaaffad16a95e1de