### PR TITLE
Fix admin buttons and allow deleting refused docs

### DIFF
--- a/packages/backend/app/Http/Controllers/JustificatifController.php
+++ b/packages/backend/app/Http/Controllers/JustificatifController.php
@@ -66,7 +66,7 @@ class JustificatifController extends Controller
             return response()->json(['message' => 'Accès interdit.'], 403);
         }
 
-        if ($justificatif->statut !== 'en_attente') {
+        if (! in_array($justificatif->statut, ['en_attente', 'refuse'])) {
             return response()->json(['message' => 'Impossible de supprimer ce document.'], 422);
         }
 

--- a/packages/backend/app/Http/Controllers/JustificatifLivreurController.php
+++ b/packages/backend/app/Http/Controllers/JustificatifLivreurController.php
@@ -80,4 +80,32 @@ class JustificatifLivreurController extends Controller
 
         return response()->json(['message' => 'Documents enregistrés.', 'livreur' => $livreur]);
     }
+
+    public function destroy($type)
+    {
+        $user = Auth::user();
+        if ($user->role !== 'livreur') {
+            return response()->json(['message' => 'Accès interdit.'], 403);
+        }
+
+        $livreur = $user->livreur;
+
+        if ($livreur->statut === 'valide') {
+            return response()->json(['message' => 'Impossible de supprimer ce document.'], 422);
+        }
+
+        if ($type === 'piece_identite' && $livreur->piece_identite_document) {
+            Storage::disk('public')->delete($livreur->piece_identite_document);
+            $livreur->piece_identite_document = null;
+        } elseif ($type === 'permis_conduire' && $livreur->permis_conduire_document) {
+            Storage::disk('public')->delete($livreur->permis_conduire_document);
+            $livreur->permis_conduire_document = null;
+        } else {
+            return response()->json(['message' => 'Document introuvable.'], 404);
+        }
+
+        $livreur->save();
+
+        return response()->json(['message' => 'Document supprimé.']);
+    }
 }

--- a/packages/backend/routes/api.php
+++ b/packages/backend/routes/api.php
@@ -111,6 +111,7 @@ Route::middleware(['auth:sanctum', 'role:admin,livreur'])->group(function () {
     Route::patch('/livreurs/{id}', [LivreurController::class, 'update'])->whereNumber('id');
     Route::get('/livreurs/{id}/justificatifs', [JustificatifLivreurController::class, 'index'])->whereNumber('id');
     Route::post('/livreurs/justificatifs', [JustificatifLivreurController::class, 'store']);
+    Route::delete('/livreurs/justificatifs/{type}', [JustificatifLivreurController::class, 'destroy']);
 
     Route::middleware('livreur.valide')->group(function () {
         Route::get('/annonces-disponibles', [AnnonceController::class, 'annoncesDisponibles']);

--- a/packages/frontend/backoffice/src/pages/admin/AdminLivreur.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/AdminLivreur.jsx
@@ -92,7 +92,7 @@ export default function AdminLivreur() {
                 </td>
                 <td className="p-3 text-sm">{l.motif_refus || ""}</td>
                 <td className="p-3 space-x-2">
-                  {!l.valide && (
+                  {l.statut === "en_attente" && (
                     <>
                       <button
                         onClick={() => valider(l.utilisateur_id)}

--- a/packages/frontend/frontoffice/src/pages/ProfilLivreur.jsx
+++ b/packages/frontend/frontoffice/src/pages/ProfilLivreur.jsx
@@ -51,6 +51,21 @@ export default function ProfilLivreur() {
     }
   };
 
+  const handleDelete = async (type) => {
+    if (!window.confirm("Supprimer ce document ?")) return;
+    try {
+      await api.delete(`/livreurs/justificatifs/${type}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setLivreur((prev) => ({
+        ...prev,
+        [`${type}_document`]: null,
+      }));
+    } catch {
+      alert("Suppression impossible");
+    }
+  };
+
   if (error) return <p className="text-red-600 p-4">{error}</p>;
   if (!livreur) return <p className="p-4">Chargement...</p>;
 
@@ -81,6 +96,14 @@ export default function ProfilLivreur() {
               >
                 Pièce d'identité
               </a>
+              {livreur.statut === "refuse" && (
+                <button
+                  onClick={() => handleDelete("piece_identite")}
+                  className="text-sm text-red-600 hover:underline"
+                >
+                  Supprimer
+                </button>
+              )}
             </li>
           )}
           {livreur.permis_conduire_document && (
@@ -93,6 +116,14 @@ export default function ProfilLivreur() {
               >
                 Permis de conduire
               </a>
+              {livreur.statut === "refuse" && (
+                <button
+                  onClick={() => handleDelete("permis_conduire")}
+                  className="text-sm text-red-600 hover:underline"
+                >
+                  Supprimer
+                </button>
+              )}
             </li>
           )}
         </ul>

--- a/packages/frontend/frontoffice/src/pages/ProfilPrestataire.jsx
+++ b/packages/frontend/frontoffice/src/pages/ProfilPrestataire.jsx
@@ -154,7 +154,7 @@ export default function ProfilPrestataire() {
               >
                 {j.chemin.split("/").pop()}
               </a>
-              {prestataire.statut === "refuse" && (
+              {j.statut === "refuse" && (
                 <button
                   onClick={() => handleDelete(j.id)}
                   className="text-sm text-red-600 hover:underline"
@@ -165,7 +165,8 @@ export default function ProfilPrestataire() {
             </li>
           ))}
         </ul>
-        {prestataire.statut === "refuse" && justificatifs.length > 0 && (
+        {prestataire.statut === "refuse" &&
+          justificatifs.some((j) => j.statut === "refuse") && (
           <p className="text-sm text-gray-600">
             📂 Vous devez supprimer les justificatifs refusés avant d’en ajouter
             un nouveau.


### PR DESCRIPTION
## Summary
- hide admin validation buttons once status changes
- allow users to delete refused justificatifs
- enable livreur document deletion via API

## Testing
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_687004d69e6c8331bbb6d69bd5dc6b23