### PR TITLE
Amélioration interface profil et navigation

### DIFF
--- a/packages/frontend/frontoffice/src/components/Navbar.jsx
+++ b/packages/frontend/frontoffice/src/components/Navbar.jsx
@@ -46,7 +46,6 @@ export default function Navbar() {
         { path: "/disponibilites", label: "Disponibilités" },
         { path: "/prestations/publier", label: "Publier une prestation" },
         { path: "/factures", label: "Factures" },
-        { path: "/profil-prestataire", label: "Mon statut" },
       ];
     }
 

--- a/packages/frontend/frontoffice/src/pages/Profil.jsx
+++ b/packages/frontend/frontoffice/src/pages/Profil.jsx
@@ -39,6 +39,22 @@ export default function Profil() {
         </Link>
       </div>
 
+      {user.role === "livreur" && (
+        <div className="text-center">
+          <Link to="/profil-livreur" className="text-blue-600 underline">
+            Statut et gestion des justificatifs
+          </Link>
+        </div>
+      )}
+
+      {user.role === "prestataire" && (
+        <div className="text-center">
+          <Link to="/profil-prestataire" className="text-blue-600 underline">
+            Statut et gestion des justificatifs
+          </Link>
+        </div>
+      )}
+
       <hr className="my-6" />
 
       <button onClick={handleDelete} className="w-full bg-red-600 text-white py-2 rounded">

--- a/packages/frontend/frontoffice/src/pages/ProfilLivreur.jsx
+++ b/packages/frontend/frontoffice/src/pages/ProfilLivreur.jsx
@@ -136,19 +136,22 @@ export default function ProfilLivreur() {
               </p>
             ) : (
               <>
+                <label className="block font-medium">Pièce d'identité</label>
                 <input
                   type="file"
                   onChange={(e) =>
                     setFiles((f) => ({ ...f, identite: e.target.files[0] }))
                   }
-                  className="block"
+                  className="mb-2 block"
                 />
+
+                <label className="block font-medium">Permis de conduire</label>
                 <input
                   type="file"
                   onChange={(e) =>
                     setFiles((f) => ({ ...f, permis: e.target.files[0] }))
                   }
-                  className="block mt-2"
+                  className="mb-2 block"
                 />
                 <button
                   onClick={handleUpload}

--- a/packages/frontend/frontoffice/src/pages/ProfilPrestataire.jsx
+++ b/packages/frontend/frontoffice/src/pages/ProfilPrestataire.jsx
@@ -174,10 +174,11 @@ export default function ProfilPrestataire() {
         )}
         {prestataire.statut === "refuse" && justificatifs.length === 0 && (
           <>
+            <label className="block font-medium">Justificatif (RIB, RC Pro, etc.)</label>
             <input
               type="file"
               onChange={(e) => setNewFile(e.target.files[0])}
-              className="mb-2"
+              className="mb-2 block"
             />
             <button
               onClick={handleUpload}


### PR DESCRIPTION
## Summary
- améliore l'affichage des champs d'upload dans les pages livreur et prestataire
- retire l'accès direct au statut prestataire depuis la barre de navigation
- ajoute un lien vers le statut depuis la page profil

## Testing
- `npm run lint` *(échoue : 5 errors, 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687009ac267c8331a7ac2148c2476e3e