### PR TITLE
Add admin search and show all profiles

### DIFF
--- a/packages/frontend/backoffice/src/pages/admin/AdminLivreur.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/AdminLivreur.jsx
@@ -6,6 +6,7 @@ const STORAGE_BASE_URL = api.defaults.baseURL.replace("/api", "");
 export default function AdminLivreur() {
   const [livreurs, setLivreurs] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
 
   useEffect(() => {
     fetchLivreurs();
@@ -48,6 +49,13 @@ export default function AdminLivreur() {
   return (
     <div className="p-6 space-y-6">
       <h1 className="text-2xl font-bold">Livreurs</h1>
+      <input
+        type="text"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Rechercher..."
+        className="border p-2 mb-4 w-full max-w-xs"
+      />
       <div className="overflow-x-auto">
         <table className="min-w-full bg-white rounded shadow">
           <thead>
@@ -62,7 +70,13 @@ export default function AdminLivreur() {
             </tr>
           </thead>
           <tbody>
-            {livreurs.map((l) => (
+            {livreurs
+              .filter(
+                (l) =>
+                  l.utilisateur?.nom.toLowerCase().includes(search.toLowerCase()) ||
+                  l.utilisateur?.prenom.toLowerCase().includes(search.toLowerCase())
+              )
+              .map((l) => (
               <tr key={l.id} className="border-b hover:bg-gray-50 align-top">
                 <td className="p-3">{l.utilisateur?.prenom} {l.utilisateur?.nom}</td>
                 <td className="p-3">{l.utilisateur?.email}</td>

--- a/packages/frontend/backoffice/src/pages/admin/AdminPrestataires.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/AdminPrestataires.jsx
@@ -9,6 +9,7 @@ export default function AdminPrestataires() {
   const [justifs, setJustifs] = useState({});
   const [evaluations, setEvaluations] = useState({});
   const [showEval, setShowEval] = useState({});
+  const [search, setSearch] = useState("");
 
   useEffect(() => {
     fetchPrestataires();
@@ -72,6 +73,13 @@ export default function AdminPrestataires() {
   return (
     <div className="p-6 space-y-6">
       <h1 className="text-2xl font-bold">Prestataires</h1>
+      <input
+        type="text"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Rechercher..."
+        className="border p-2 mb-4 w-full max-w-xs"
+      />
       <div className="overflow-x-auto">
         <table className="min-w-full bg-white rounded shadow">
           <thead>
@@ -85,7 +93,13 @@ export default function AdminPrestataires() {
             </tr>
           </thead>
           <tbody>
-            {prestataires.map((p) => (
+            {prestataires
+              .filter(
+                (p) =>
+                  p.utilisateur?.nom.toLowerCase().includes(search.toLowerCase()) ||
+                  p.utilisateur?.prenom.toLowerCase().includes(search.toLowerCase())
+              )
+              .map((p) => (
               <tr key={p.id} className="border-b hover:bg-gray-50 align-top">
                 <td className="p-3">{p.utilisateur?.prenom} {p.utilisateur?.nom}</td>
                 <td className="p-3">{p.utilisateur?.email}</td>


### PR DESCRIPTION
## Summary
- show search bar and filter logic in `AdminLivreur.jsx`
- add equivalent search bar and filter logic in `AdminPrestataires.jsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68700bce90f48331a671da95d8b13299