### PR TITLE
Add unified button styles

### DIFF
--- a/packages/frontend/backoffice/src/components/Navbar.jsx
+++ b/packages/frontend/backoffice/src/components/Navbar.jsx
@@ -20,7 +20,7 @@ export default function Navbar() {
         {!token ? (
           <Link
             to="/login"
-            className="bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded text-white"
+            className="admin-btn-primary"
           >
             Se connecter
           </Link>
@@ -102,7 +102,7 @@ export default function Navbar() {
 
             <button
               onClick={handleLogout}
-              className="bg-red-500 hover:bg-red-600 px-4 py-2 rounded"
+              className="admin-btn-danger"
             >
               Déconnexion
             </button>

--- a/packages/frontend/backoffice/src/index.css
+++ b/packages/frontend/backoffice/src/index.css
@@ -6,3 +6,14 @@
 @tailwind utilities;
 
 
+.admin-btn-primary {
+  @apply bg-blue-900 text-white px-4 py-2 rounded-md font-semibold hover:bg-blue-800 transition;
+}
+
+.admin-btn-secondary {
+  @apply bg-gray-200 text-gray-900 px-4 py-2 rounded-md font-semibold hover:bg-gray-300 transition;
+}
+
+.admin-btn-danger {
+  @apply bg-red-700 text-white px-4 py-2 rounded-md font-semibold hover:bg-red-800 transition;
+}

--- a/packages/frontend/backoffice/src/pages/Login.jsx
+++ b/packages/frontend/backoffice/src/pages/Login.jsx
@@ -42,7 +42,7 @@ export default function Login() {
       />
       <button
         type="submit"
-        className="w-full bg-blue-600 text-white p-2 rounded hover:bg-blue-700"
+        className="admin-btn-primary w-full"
       >
         Se connecter
       </button>

--- a/packages/frontend/backoffice/src/pages/admin/AddAdmin.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/AddAdmin.jsx
@@ -127,14 +127,14 @@ export default function AddAdmin() {
         <div className="flex gap-4">
           <button
             type="submit"
-            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+            className="admin-btn-primary"
           >
             Créer
           </button>
           <button
             type="button"
             onClick={handleCancel}
-            className="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600"
+            className="admin-btn-secondary"
           >
             Annuler
           </button>

--- a/packages/frontend/backoffice/src/pages/admin/AddUser.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/AddUser.jsx
@@ -148,14 +148,14 @@ export default function AddUser() {
         <div className="flex gap-4">
           <button
             type="submit"
-            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+            className="admin-btn-primary"
           >
             Créer
           </button>
           <button
             type="button"
             onClick={handleCancel}
-            className="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600"
+            className="admin-btn-secondary"
           >
             Annuler
           </button>

--- a/packages/frontend/backoffice/src/pages/admin/AnnoncesList.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/AnnoncesList.jsx
@@ -156,7 +156,7 @@ export default function AnnoncesList() {
         <div className="flex gap-4">
           <button
             type="submit"
-            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+            className="admin-btn-primary"
           >
             {editingId ? "Mettre à jour" : "Ajouter"}
           </button>
@@ -164,7 +164,7 @@ export default function AnnoncesList() {
             <button
               type="button"
               onClick={resetForm}
-              className="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600"
+              className="admin-btn-secondary"
             >
               Annuler
             </button>

--- a/packages/frontend/backoffice/src/pages/admin/EditUserForm.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/EditUserForm.jsx
@@ -130,7 +130,7 @@ export default function EditUserForm() {
             </select>
         </div>
 
-        <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
+        <button type="submit" className="admin-btn-primary">
           Enregistrer
         </button>
       </form>

--- a/packages/frontend/backoffice/src/pages/admin/EntrepotsList.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/EntrepotsList.jsx
@@ -166,7 +166,7 @@ export default function EntrepotsList() {
         <div className="flex gap-4">
           <button
             type="submit"
-            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+            className="admin-btn-primary"
           >
             {editingId ? "Mettre \xE0 jour" : "Ajouter"}
           </button>
@@ -174,7 +174,7 @@ export default function EntrepotsList() {
             <button
               type="button"
               onClick={resetForm}
-              className="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600"
+              className="admin-btn-secondary"
             >
               Annuler
             </button>

--- a/packages/frontend/backoffice/src/pages/admin/PrestationList.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/PrestationList.jsx
@@ -234,14 +234,14 @@ export default function PrestationList() {
           {errors.statut && <p className="text-red-600 text-sm">{errors.statut[0]}</p>}
         </div>
         <div className="flex gap-4">
-          <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
+          <button type="submit" className="admin-btn-primary">
             {editingId ? "Mettre à jour" : "Ajouter"}
           </button>
           {editingId && (
             <button
               type="button"
               onClick={resetForm}
-              className="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600"
+              className="admin-btn-secondary"
             >
               Annuler
             </button>

--- a/packages/frontend/backoffice/src/pages/admin/UserDetails.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/UserDetails.jsx
@@ -42,7 +42,7 @@ export default function UserDetails() {
         </Link>
         <Link
           to="/admin/utilisateurs"
-          className="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600"
+          className="admin-btn-secondary"
         >
           Retour
         </Link>

--- a/packages/frontend/backoffice/src/pages/admin/UsersList.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/UsersList.jsx
@@ -23,13 +23,13 @@ export default function UsersList() {
         <div className="flex gap-2">
           <button
             onClick={() => navigate("/admin/utilisateurs/ajouter-admin")}
-            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+            className="admin-btn-primary"
           >
             Créer un admin
           </button>
           <button
             onClick={() => navigate("/admin/utilisateurs/ajouter")}
-            className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+            className="admin-btn-primary"
           >
             Ajouter un utilisateur
           </button>

--- a/packages/frontend/frontoffice/src/components/ActionButtons.jsx
+++ b/packages/frontend/frontoffice/src/components/ActionButtons.jsx
@@ -34,14 +34,14 @@ export default function ActionButtons({ prestationId, statut, onChange }) {
           <button
             onClick={() => changerStatut("acceptée")}
             disabled={loading}
-            className="bg-green-600 text-white px-3 py-1 rounded disabled:opacity-50"
+            className="btn-primary disabled:opacity-50"
           >
             Accepter
           </button>
           <button
             onClick={() => changerStatut("refusée")}
             disabled={loading}
-            className="bg-red-600 text-white px-3 py-1 rounded disabled:opacity-50"
+            className="btn-danger disabled:opacity-50"
           >
             Refuser
           </button>
@@ -52,7 +52,7 @@ export default function ActionButtons({ prestationId, statut, onChange }) {
         <button
           onClick={() => changerStatut("terminée")}
           disabled={loading}
-          className="bg-blue-600 text-white px-3 py-1 rounded disabled:opacity-50"
+          className="btn-primary disabled:opacity-50"
         >
           Terminer
         </button>

--- a/packages/frontend/frontoffice/src/components/EvaluationForm.jsx
+++ b/packages/frontend/frontoffice/src/components/EvaluationForm.jsx
@@ -62,7 +62,7 @@ export default function EvaluationForm({ interventionId, onSubmit }) {
       <button
         type="submit"
         disabled={loading}
-        className="bg-green-600 text-white px-4 py-2 rounded disabled:opacity-50"
+        className="btn-primary disabled:opacity-50"
       >
         {loading ? "Envoi..." : "Envoyer"}
       </button>

--- a/packages/frontend/frontoffice/src/components/FactureCard.jsx
+++ b/packages/frontend/frontoffice/src/components/FactureCard.jsx
@@ -15,7 +15,7 @@ export default function FactureCard({ facture }) {
         href={url}
         target="_blank"
         rel="noopener noreferrer"
-        className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+        className="btn-primary"
       >
         Télécharger PDF
       </a>

--- a/packages/frontend/frontoffice/src/components/PlanningForm.jsx
+++ b/packages/frontend/frontoffice/src/components/PlanningForm.jsx
@@ -53,7 +53,7 @@ export default function PlanningForm({ onSubmit }) {
           className="flex-1 p-2 border rounded"
         />
       </div>
-      <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700">
+      <button type="submit" className="btn-primary w-full">
         Ajouter
       </button>
     </form>

--- a/packages/frontend/frontoffice/src/index.css
+++ b/packages/frontend/frontoffice/src/index.css
@@ -6,3 +6,14 @@
 @tailwind utilities;
 
 
+.btn-primary {
+  @apply bg-green-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-green-700 transition;
+}
+
+.btn-secondary {
+  @apply bg-gray-100 text-gray-800 px-4 py-2 rounded-lg font-medium hover:bg-gray-200 transition;
+}
+
+.btn-danger {
+  @apply bg-red-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-red-700 transition;
+}

--- a/packages/frontend/frontoffice/src/pages/AnnonceDetail.jsx
+++ b/packages/frontend/frontoffice/src/pages/AnnonceDetail.jsx
@@ -62,7 +62,7 @@ export default function AnnonceDetail() {
       {user?.role === "client" && !annonce.id_client && (
         <button
           onClick={reserver}
-          className="mt-4 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+          className="btn-primary mt-4"
         >
           Réserver
         </button>

--- a/packages/frontend/frontoffice/src/pages/Annonces.jsx
+++ b/packages/frontend/frontoffice/src/pages/Annonces.jsx
@@ -89,7 +89,7 @@ export default function Annonces() {
       {["client", "commercant"].includes(user?.role) && (
         <button
           onClick={() => navigate("/annonces/creer")}
-          className="mb-4 px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
+          className="btn-primary mb-4"
         >
           Créer une annonce
         </button>
@@ -139,7 +139,7 @@ export default function Annonces() {
         />
         <button
           onClick={handleReset}
-          className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300"
+          className="btn-secondary"
         >
           Réinitialiser les filtres
         </button>
@@ -167,7 +167,7 @@ export default function Annonces() {
 
               <button
                 onClick={() => navigate(`/annonces/${annonce.id}`)}
-                className="mt-3 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+                className="btn-primary mt-3"
               >
                 Voir l'annonce
               </button>

--- a/packages/frontend/frontoffice/src/pages/AnnoncesDisponibles.jsx
+++ b/packages/frontend/frontoffice/src/pages/AnnoncesDisponibles.jsx
@@ -144,7 +144,7 @@ export default function AnnoncesDisponibles() {
         />
         <button
           onClick={handleReset}
-          className="px-4 py-2 bg-gray-200 rounded hover:bg-gray-300"
+          className="btn-secondary"
         >
           Réinitialiser les filtres
         </button>
@@ -166,7 +166,7 @@ export default function AnnoncesDisponibles() {
 
               <button
                 onClick={() => handleAccepter(a.id)}
-                className="mt-4 bg-green-700 text-white px-4 py-2 rounded hover:bg-green-800"
+                className="btn-primary mt-4"
               >
                 Accepter l’annonce
               </button>

--- a/packages/frontend/frontoffice/src/pages/ChangePassword.jsx
+++ b/packages/frontend/frontoffice/src/pages/ChangePassword.jsx
@@ -50,7 +50,7 @@ export default function ChangePassword() {
         <input type="password" placeholder="Mot de passe actuel" value={currentPassword} onChange={(e) => setCurrentPassword(e.target.value)} className="w-full p-2 border rounded" required />
         <input type="password" placeholder="Nouveau mot de passe" value={newPassword} onChange={(e) => setNewPassword(e.target.value)} className="w-full p-2 border rounded" required />
         <input type="password" placeholder="Confirmation du mot de passe" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} className="w-full p-2 border rounded" required />
-        <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">Valider</button>
+        <button type="submit" className="btn-primary w-full">Valider</button>
       </form>
 
       <div className="mt-4 text-center space-y-1">

--- a/packages/frontend/frontoffice/src/pages/CreerAnnonce.jsx
+++ b/packages/frontend/frontoffice/src/pages/CreerAnnonce.jsx
@@ -206,7 +206,7 @@ export default function CreerAnnonce() {
         <button
           type="submit"
           disabled={loading || entrepots.length === 0}
-          className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+          className="btn-primary w-full disabled:opacity-50"
         >
           {loading ? "Création..." : "Créer l'annonce"}
         </button>

--- a/packages/frontend/frontoffice/src/pages/EditMesAnnonce.jsx
+++ b/packages/frontend/frontoffice/src/pages/EditMesAnnonce.jsx
@@ -150,14 +150,14 @@ export default function EditMesAnnonce() {
           <div className="flex gap-4">
             <button
               type="submit"
-              className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+              className="btn-primary"
             >
               Enregistrer
             </button>
             <button
               type="button"
               onClick={handleDelete}
-              className="bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700"
+              className="btn-danger"
             >
               Supprimer
             </button>

--- a/packages/frontend/frontoffice/src/pages/EditProfil.jsx
+++ b/packages/frontend/frontoffice/src/pages/EditProfil.jsx
@@ -122,7 +122,7 @@ export default function EditProfil() {
           </>
         )}
 
-        <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">Enregistrer les modifications</button>
+        <button type="submit" className="btn-primary w-full">Enregistrer les modifications</button>
       </form>
 
       <div className="mt-4 text-center">

--- a/packages/frontend/frontoffice/src/pages/Login.jsx
+++ b/packages/frontend/frontoffice/src/pages/Login.jsx
@@ -74,7 +74,7 @@ export default function Login() {
 
       <button
         type="submit"
-        className="w-full bg-blue-600 text-white p-2 rounded hover:bg-blue-700"
+        className="btn-primary w-full"
       >
         Se connecter
       </button>

--- a/packages/frontend/frontoffice/src/pages/MesAnnonces.jsx
+++ b/packages/frontend/frontoffice/src/pages/MesAnnonces.jsx
@@ -172,7 +172,7 @@ export default function MesAnnonces() {
                 <button
                   onClick={() => handlePay(a)}
                   disabled={payLoadingId === a.id}
-                  className="mt-2 bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700 disabled:opacity-50"
+                  className="btn-primary mt-2 disabled:opacity-50"
                 >
                   {payLoadingId === a.id ? "Redirection..." : "Payer maintenant"}
                 </button>
@@ -182,7 +182,7 @@ export default function MesAnnonces() {
               {a.etapes_livraison?.length === 0 && (!a.id_client || a.type !== "produit_livre") && (
                 <button
                   onClick={() => handleDelete(a.id)}
-                  className="mt-4 bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700"
+                  className="btn-danger mt-4"
                 >
                   Annuler l’annonce
                 </button>

--- a/packages/frontend/frontoffice/src/pages/MesEtapes.jsx
+++ b/packages/frontend/frontoffice/src/pages/MesEtapes.jsx
@@ -79,7 +79,7 @@ export default function MesEtapes() {
                 boutonAction = (
                   <Link
                     to={`/validation-code/${e.id}?type=retrait`}
-                    className="inline-block mt-3 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+                    className="btn-primary inline-block mt-3"
                   >
                     Saisir le code pour retirer
                   </Link>
@@ -91,7 +91,7 @@ export default function MesEtapes() {
                     onClick={() =>
                       navigate(`/validation-code/${e.id}?type=retrait`)
                     }
-                    className="inline-block mt-3 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+                    className="btn-primary inline-block mt-3"
                   >
                     Saisir le code pour retirer
                   </button>
@@ -102,7 +102,7 @@ export default function MesEtapes() {
               boutonAction = (
                 <Link
                   to={`/validation-code/${e.id}?type=depot`}
-                  className="inline-block mt-3 bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+                  className="btn-primary inline-block mt-3"
                 >
                   Saisir le code pour déposer
                 </Link>

--- a/packages/frontend/frontoffice/src/pages/MesTrajets.jsx
+++ b/packages/frontend/frontoffice/src/pages/MesTrajets.jsx
@@ -147,7 +147,7 @@ export default function MesTrajets() {
           onChange={handleChange}
           className="w-full p-2 border rounded"
         />
-        <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
+        <button type="submit" className="btn-primary">
           Ajouter le trajet
         </button>
       </form>

--- a/packages/frontend/frontoffice/src/pages/Profil.jsx
+++ b/packages/frontend/frontoffice/src/pages/Profil.jsx
@@ -34,7 +34,7 @@ export default function Profil() {
       </div>
 
       <div className="text-center mt-4">
-        <Link to="/profil/edit" className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">
+        <Link to="/profil/edit" className="btn-primary">
           Modifier mes informations
         </Link>
       </div>
@@ -57,7 +57,7 @@ export default function Profil() {
 
       <hr className="my-6" />
 
-      <button onClick={handleDelete} className="w-full bg-red-600 text-white py-2 rounded">
+      <button onClick={handleDelete} className="btn-danger w-full">
         Supprimer mon compte
       </button>
     </div>

--- a/packages/frontend/frontoffice/src/pages/ProfilLivreur.jsx
+++ b/packages/frontend/frontoffice/src/pages/ProfilLivreur.jsx
@@ -156,7 +156,7 @@ export default function ProfilLivreur() {
                 <button
                   onClick={handleUpload}
                   disabled={uploading}
-                  className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50 mt-2"
+                  className="btn-primary mt-2 disabled:opacity-50"
                 >
                   {uploading ? "Envoi..." : "Envoyer"}
                 </button>

--- a/packages/frontend/frontoffice/src/pages/ProfilPrestataire.jsx
+++ b/packages/frontend/frontoffice/src/pages/ProfilPrestataire.jsx
@@ -183,7 +183,7 @@ export default function ProfilPrestataire() {
             <button
               onClick={handleUpload}
               disabled={uploading}
-              className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+              className="btn-primary disabled:opacity-50"
             >
               {uploading ? "Envoi..." : "Ajouter"}
             </button>

--- a/packages/frontend/frontoffice/src/pages/PublierPrestation.jsx
+++ b/packages/frontend/frontoffice/src/pages/PublierPrestation.jsx
@@ -173,7 +173,7 @@ export default function PublierPrestation() {
         <button
           type="submit"
           disabled={loading}
-          className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+          className="btn-primary w-full disabled:opacity-50"
         >
           {loading ? "Publication..." : "Publier"}
         </button>

--- a/packages/frontend/frontoffice/src/pages/Register.jsx
+++ b/packages/frontend/frontoffice/src/pages/Register.jsx
@@ -123,19 +123,19 @@ export default function Register() {
       <div className="flex justify-center gap-4 mb-6">
         <button
           onClick={() => navigate("/register-livreur")}
-          className="bg-gray-200 hover:bg-gray-300 text-sm px-4 py-2 rounded"
+          className="btn-secondary text-sm"
         >
           Je suis un livreur
         </button>
         <button
           onClick={() => navigate("/register-commercant")}
-          className="bg-gray-200 hover:bg-gray-300 text-sm px-4 py-2 rounded"
+          className="btn-secondary text-sm"
         >
           Je suis un commerçant
         </button>
         <button
           onClick={() => navigate("/register-prestataire")}
-          className="bg-gray-200 hover:bg-gray-300 text-sm px-4 py-2 rounded"
+          className="btn-secondary text-sm"
         >
           Je suis un prestataire
         </button>
@@ -171,7 +171,7 @@ export default function Register() {
         </div>
         {errors.rgpd_consent && <p className="text-red-500 text-sm">{errors.rgpd_consent}</p>}
 
-        <button type="submit" className="w-full bg-blue-600 text-white p-2 rounded hover:bg-blue-700">
+        <button type="submit" className="btn-primary w-full">
           S'inscrire
         </button>
       </form>

--- a/packages/frontend/frontoffice/src/pages/RegisterCommercant.jsx
+++ b/packages/frontend/frontoffice/src/pages/RegisterCommercant.jsx
@@ -176,7 +176,7 @@ export default function RegisterCommercant() {
       </div>
       {errors.rgpd_consent && <p className="text-red-500 text-sm">{errors.rgpd_consent}</p>}
 
-      <button type="submit" className="w-full bg-blue-600 text-white p-2 rounded hover:bg-blue-700">
+      <button type="submit" className="btn-primary w-full">
         S'inscrire
       </button>
     </form>

--- a/packages/frontend/frontoffice/src/pages/RegisterLivreur.jsx
+++ b/packages/frontend/frontoffice/src/pages/RegisterLivreur.jsx
@@ -188,7 +188,7 @@ export default function RegisterLivreur() {
       </div>
       {errors.rgpd_consent && <p className="text-red-500 text-sm">{errors.rgpd_consent}</p>}
 
-      <button type="submit" className="w-full bg-blue-600 text-white p-2 rounded hover:bg-blue-700">
+      <button type="submit" className="btn-primary w-full">
         S'inscrire
       </button>
     </form>

--- a/packages/frontend/frontoffice/src/pages/RegisterPrestataire.jsx
+++ b/packages/frontend/frontoffice/src/pages/RegisterPrestataire.jsx
@@ -193,7 +193,7 @@ export default function RegisterPrestataire() {
       </div>
       {errors.rgpd_consent && <p className="text-red-500 text-sm">{errors.rgpd_consent}</p>}
 
-      <button type="submit" className="w-full bg-blue-600 text-white p-2 rounded hover:bg-blue-700">
+      <button type="submit" className="btn-primary w-full">
         S'inscrire
       </button>
     </form>

--- a/packages/frontend/frontoffice/src/pages/ReserverAnnonce.jsx
+++ b/packages/frontend/frontoffice/src/pages/ReserverAnnonce.jsx
@@ -123,7 +123,7 @@ export default function ReserverAnnonce() {
       <button
         onClick={reserver}
         disabled={loading}
-        className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50"
+        className="btn-primary disabled:opacity-50"
       >
         {loading ? "Redirection..." : "Réserver"}
       </button>

--- a/packages/frontend/frontoffice/src/pages/SuiviAnnonce.jsx
+++ b/packages/frontend/frontoffice/src/pages/SuiviAnnonce.jsx
@@ -226,7 +226,7 @@ function EtapeForm({ titre, code, setCode, loading, valider, message, etatCode, 
         />
         <button
           type="submit"
-          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+          className="btn-primary"
           disabled={loading}
         >
           {loading

--- a/packages/frontend/frontoffice/src/pages/ValidationCodeBox.jsx
+++ b/packages/frontend/frontoffice/src/pages/ValidationCodeBox.jsx
@@ -160,7 +160,7 @@ export default function ValidationCodeBox() {
 
         <button
           type="submit"
-          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+          className="btn-primary"
           disabled={loading}
         >
           {loading


### PR DESCRIPTION
## Summary
- add frontoffice button classes
- add backoffice admin button classes
- replace inline button styles with these classes across both apps

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68701f64eddc8331ba9d8703e1e2102e