### PR TITLE
Add Docker files for Laravel and React apps

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,71 @@
+version: '3.9'
+
+services:
+  backend:
+    build: ./packages/backend
+    container_name: backend
+    ports:
+      - "8000:8000"
+    volumes:
+      - backend-storage:/app/storage
+    environment:
+      DB_CONNECTION: pgsql
+      DB_HOST: postgres
+      DB_PORT: 5432
+      DB_DATABASE: ecodeli_pa
+      DB_USERNAME: postgres
+      DB_PASSWORD: ""
+    depends_on:
+      - postgres
+    networks:
+      - ecodeli
+
+  frontoffice:
+    build: ./packages/frontend/frontoffice
+    container_name: frontoffice
+    ports:
+      - "4173:4173"
+    depends_on:
+      - backend
+    networks:
+      - ecodeli
+
+  backoffice:
+    build: ./packages/frontend/backoffice
+    container_name: backoffice
+    ports:
+      - "4174:4174"
+    depends_on:
+      - backend
+    networks:
+      - ecodeli
+
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: ecodeli_pa
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ""
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    networks:
+      - ecodeli
+
+  mailhog:
+    image: mailhog/mailhog
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+    networks:
+      - ecodeli
+
+volumes:
+  db-data:
+  backend-storage:
+
+networks:
+  ecodeli:
+    driver: bridge

--- a/packages/backend/.dockerignore
+++ b/packages/backend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+vendor
+.env
+npm-debug.log

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -1,0 +1,28 @@
+FROM php:8.2-cli
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    git unzip libzip-dev libpng-dev libonig-dev libxml2-dev libpq-dev \
+    nodejs npm && \
+    docker-php-ext-install pdo pdo_pgsql zip
+
+# Install Composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /app
+COPY . .
+
+# Prepare environment
+RUN cp .env.example .env && \
+    sed -i 's/DB_HOST=127.0.0.1/DB_HOST=postgres/' .env
+
+# Install PHP and JS dependencies and build assets
+RUN composer install --no-interaction --prefer-dist && \
+    npm install && npm run build && \
+    php artisan key:generate --force
+
+# Fix permissions
+RUN chown -R www-data:www-data storage bootstrap/cache
+
+EXPOSE 8000
+CMD php artisan migrate --seed && php artisan serve --host=0.0.0.0 --port=8000

--- a/packages/frontend/backoffice/.dockerignore
+++ b/packages/frontend/backoffice/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+npm-debug.log

--- a/packages/frontend/backoffice/Dockerfile
+++ b/packages/frontend/backoffice/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:18-alpine as build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:18-alpine
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/package*.json ./
+EXPOSE 4173
+CMD ["npm", "run", "preview", "--", "--host", "0.0.0.0", "--port", "4174"]

--- a/packages/frontend/frontoffice/.dockerignore
+++ b/packages/frontend/frontoffice/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+npm-debug.log

--- a/packages/frontend/frontoffice/Dockerfile
+++ b/packages/frontend/frontoffice/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:18-alpine as build
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM node:18-alpine
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/package*.json ./
+EXPOSE 4173
+CMD ["npm", "run", "preview", "--", "--host", "0.0.0.0", "--port", "4173"]


### PR DESCRIPTION
## Summary
- add Dockerfiles for Laravel backend and React frontends
- add .dockerignore files
- add docker-compose.yml with backend, frontoffice, backoffice, postgres and mailhog services

## Testing
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871559ce9c0833189fb62297974dbd0