### PR TITLE
Restrict admin actions

### DIFF
--- a/packages/backend/app/Http/Controllers/AnnonceController.php
+++ b/packages/backend/app/Http/Controllers/AnnonceController.php
@@ -64,6 +64,10 @@ class AnnonceController extends Controller
     {
         $user = Auth::user();
 
+        if (! in_array($user->role, ['client', 'commercant'])) {
+            return response()->json(['message' => 'Action non autorisée.'], 403);
+        }
+
         // Déterminer les règles dynamiquement selon le rôle
         $rules = [
             'type' => 'required|in:livraison_client,produit_livre',
@@ -126,8 +130,8 @@ class AnnonceController extends Controller
         }
 
         if (
-            $annonce->type === 'produit_livre' &&
-            $annonce->id_client !== null
+            ($annonce->type === 'produit_livre' && $annonce->id_client !== null) ||
+            ($annonce->type === 'livraison_client' && $annonce->id_livreur_reservant !== null)
         ) {
             return response()->json(['message' => 'Cette annonce a déjà été réservée et ne peut plus être modifiée.'], 403);
         }
@@ -165,8 +169,8 @@ class AnnonceController extends Controller
         }
 
         if (
-            $annonce->type === 'produit_livre' &&
-            $annonce->id_client !== null
+            ($annonce->type === 'produit_livre' && $annonce->id_client !== null) ||
+            ($annonce->type === 'livraison_client' && $annonce->id_livreur_reservant !== null)
         ) {
             return response()->json(['message' => 'Cette annonce a déjà été réservée et ne peut plus être modifiée.'], 403);
         }

--- a/packages/backend/app/Http/Controllers/PrestationController.php
+++ b/packages/backend/app/Http/Controllers/PrestationController.php
@@ -128,8 +128,8 @@ class PrestationController extends Controller
             return response()->json(['message' => 'Prestation introuvable.'], 404);
         }
 
-        if ($prestation->statut !== 'en_attente') {
-            return response()->json(['message' => 'Impossible de modifier une prestation non en attente.'], 403);
+        if ($prestation->client_id !== null || $prestation->prestataire_id !== null) {
+            return response()->json(['message' => 'Impossible de modifier une prestation déjà réservée ou assignée.'], 403);
         }
 
         $user = Auth::user();
@@ -167,8 +167,8 @@ class PrestationController extends Controller
             return response()->json(['message' => 'Suppression non autorisée.'], 403);
         }
 
-        if ($prestation->statut !== 'en_attente') {
-            return response()->json(['message' => 'Impossible de supprimer une prestation déjà validée ou refusée.'], 403);
+        if ($prestation->client_id !== null || $prestation->prestataire_id !== null) {
+            return response()->json(['message' => 'Impossible de supprimer une prestation déjà réservée ou assignée.'], 403);
         }
 
         $prestation->delete();

--- a/packages/frontend/backoffice/src/pages/admin/AnnoncesList.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/AnnoncesList.jsx
@@ -4,7 +4,7 @@ import api from "../../services/api";
 export default function AnnoncesList() {
   const [annonces, setAnnonces] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [form, setForm] = useState({ titre: "", description: "", prix_propose: "" });
+  const [form, setForm] = useState({ titre: "", description: "" });
   const [editingId, setEditingId] = useState(null);
   const [errors, setErrors] = useState({});
   const [apiError, setApiError] = useState("");
@@ -25,6 +25,13 @@ export default function AnnoncesList() {
     }
   };
 
+  const isEngagee = (a) => {
+    return (
+      (a.type === "livraison_client" && a.id_livreur_reservant) ||
+      (a.type === "produit_livre" && a.id_client)
+    );
+  };
+
   const handleChange = (e) => {
     setForm({ ...form, [e.target.name]: e.target.value });
   };
@@ -35,22 +42,6 @@ export default function AnnoncesList() {
 
     if (editingId) {
       await updateAnnonce();
-    } else {
-      await createAnnonce();
-    }
-  };
-
-  const createAnnonce = async () => {
-    try {
-      const res = await api.post("/annonces", form);
-      setAnnonces([...annonces, res.data.annonce]);
-      resetForm();
-    } catch (err) {
-      if (err.response?.data?.errors) {
-        setErrors(err.response.data.errors);
-      } else {
-        setApiError(err.response?.data?.message || "Erreur lors de la création");
-      }
     }
   };
 
@@ -74,13 +65,12 @@ export default function AnnoncesList() {
     setForm({
       titre: annonce.titre || "",
       description: annonce.description || "",
-      prix_propose: annonce.prix_propose || "",
     });
     setErrors({});
   };
 
   const resetForm = () => {
-    setForm({ titre: "", description: "", prix_propose: "" });
+    setForm({ titre: "", description: "" });
     setEditingId(null);
   };
 
@@ -115,7 +105,7 @@ export default function AnnoncesList() {
 
       <form onSubmit={handleSubmit} className="bg-white shadow p-4 rounded space-y-4">
         <h2 className="text-xl font-semibold">
-          {editingId ? "Modifier l'annonce" : "Nouvelle annonce"}
+          {editingId ? "Modifier l'annonce" : "Sélectionner une annonce"}
         </h2>
         <div>
           <label className="block font-semibold">Titre</label>
@@ -140,26 +130,15 @@ export default function AnnoncesList() {
             <p className="text-red-600 text-sm">{errors.description[0]}</p>
           )}
         </div>
-        <div>
-          <label className="block font-semibold">Prix proposé</label>
-          <input
-            type="number"
-            name="prix_propose"
-            value={form.prix_propose}
-            onChange={handleChange}
-            className="w-full border p-2 rounded"
-          />
-          {errors.prix_propose && (
-            <p className="text-red-600 text-sm">{errors.prix_propose[0]}</p>
-          )}
-        </div>
         <div className="flex gap-4">
-          <button
-            type="submit"
-            className="admin-btn-primary"
-          >
-            {editingId ? "Mettre à jour" : "Ajouter"}
-          </button>
+          {editingId && (
+            <button
+              type="submit"
+              className="admin-btn-primary"
+            >
+              Mettre à jour
+            </button>
+          )}
           {editingId && (
             <button
               type="button"
@@ -178,7 +157,6 @@ export default function AnnoncesList() {
             <tr className="bg-gray-100 text-left text-sm uppercase text-gray-600">
               <th className="p-3">Titre</th>
               <th className="p-3">Description</th>
-              <th className="p-3">Prix</th>
               <th className="p-3">Actions</th>
             </tr>
           </thead>
@@ -187,20 +165,23 @@ export default function AnnoncesList() {
               <tr key={a.id} className="border-b hover:bg-gray-50">
                 <td className="p-3">{a.titre}</td>
                 <td className="p-3">{a.description}</td>
-                <td className="p-3">{a.prix_propose}</td>
                 <td className="p-3 space-x-2">
-                  <button
-                    onClick={() => startEdit(a)}
-                    className="text-yellow-600 hover:underline"
-                  >
-                    Modifier
-                  </button>
-                  <button
-                    onClick={() => deleteAnnonce(a.id)}
-                    className="text-red-600 hover:underline"
-                  >
-                    Supprimer
-                  </button>
+                  {!isEngagee(a) && (
+                    <>
+                      <button
+                        onClick={() => startEdit(a)}
+                        className="text-yellow-600 hover:underline"
+                      >
+                        Modifier
+                      </button>
+                      <button
+                        onClick={() => deleteAnnonce(a.id)}
+                        className="text-red-600 hover:underline"
+                      >
+                        Supprimer
+                      </button>
+                    </>
+                  )}
                 </td>
               </tr>
             ))}

--- a/packages/frontend/backoffice/src/pages/admin/PrestationList.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/PrestationList.jsx
@@ -5,14 +5,8 @@ export default function PrestationList() {
   const [prestations, setPrestations] = useState([]);
   const [loading, setLoading] = useState(true);
   const [form, setForm] = useState({
-    prestataire_id: "",
-    client_id: "",
     type_prestation: "",
     description: "",
-    date_heure: "",
-    duree_estimee: "",
-    tarif: "",
-    statut: "en_attente",
   });
   const [editingId, setEditingId] = useState(null);
   const [errors, setErrors] = useState({});
@@ -45,24 +39,8 @@ export default function PrestationList() {
 
     if (editingId) {
       await updatePrestation();
-    } else {
-      await createPrestation();
     }
   };
-
-  async function createPrestation() {
-    try {
-      const res = await api.post("/prestations", form);
-      setPrestations([...prestations, res.data.prestation]);
-      resetForm();
-    } catch (err) {
-      if (err.response?.data?.errors) {
-        setErrors(err.response.data.errors);
-      } else {
-        setApiError(err.response?.data?.message || "Erreur lors de la création");
-      }
-    }
-  }
 
   async function updatePrestation() {
     try {
@@ -90,32 +68,21 @@ export default function PrestationList() {
     }
   }
 
+  const isEngagee = (p) => {
+    return p.client_id || p.prestataire_id;
+  };
+
   const startEdit = (prestation) => {
     setEditingId(prestation.id);
     setForm({
-      prestataire_id: prestation.prestataire_id || "",
-      client_id: prestation.client_id || "",
       type_prestation: prestation.type_prestation || "",
       description: prestation.description || "",
-      date_heure: prestation.date_heure || "",
-      duree_estimee: prestation.duree_estimee || "",
-      tarif: prestation.tarif || "",
-      statut: prestation.statut || "en_attente",
     });
     setErrors({});
   };
 
   const resetForm = () => {
-    setForm({
-      prestataire_id: "",
-      client_id: "",
-      type_prestation: "",
-      description: "",
-      date_heure: "",
-      duree_estimee: "",
-      tarif: "",
-      statut: "en_attente",
-    });
+    setForm({ type_prestation: "", description: "" });
     setEditingId(null);
   };
 
@@ -132,34 +99,8 @@ export default function PrestationList() {
 
       <form onSubmit={handleSubmit} className="bg-white shadow p-4 rounded space-y-4">
         <h2 className="text-xl font-semibold">
-          {editingId ? "Modifier la prestation" : "Nouvelle prestation"}
+          {editingId ? "Modifier la prestation" : "Sélectionner une prestation"}
         </h2>
-        <div>
-          <label className="block font-semibold">Prestataire ID</label>
-          <input
-            type="number"
-            name="prestataire_id"
-            value={form.prestataire_id}
-            onChange={handleChange}
-            className="w-full border p-2 rounded"
-          />
-          {errors.prestataire_id && (
-            <p className="text-red-600 text-sm">{errors.prestataire_id[0]}</p>
-          )}
-        </div>
-        <div>
-          <label className="block font-semibold">Client ID</label>
-          <input
-            type="number"
-            name="client_id"
-            value={form.client_id}
-            onChange={handleChange}
-            className="w-full border p-2 rounded"
-          />
-          {errors.client_id && (
-            <p className="text-red-600 text-sm">{errors.client_id[0]}</p>
-          )}
-        </div>
         <div>
           <label className="block font-semibold">Type</label>
           <input
@@ -185,58 +126,12 @@ export default function PrestationList() {
             <p className="text-red-600 text-sm">{errors.description[0]}</p>
           )}
         </div>
-        <div>
-          <label className="block font-semibold">Date et heure</label>
-          <input
-            type="datetime-local"
-            name="date_heure"
-            value={form.date_heure}
-            onChange={handleChange}
-            className="w-full border p-2 rounded"
-          />
-          {errors.date_heure && (
-            <p className="text-red-600 text-sm">{errors.date_heure[0]}</p>
-          )}
-        </div>
-        <div>
-          <label className="block font-semibold">Durée estimée (min)</label>
-          <input
-            type="number"
-            name="duree_estimee"
-            value={form.duree_estimee}
-            onChange={handleChange}
-            className="w-full border p-2 rounded"
-          />
-          {errors.duree_estimee && (
-            <p className="text-red-600 text-sm">{errors.duree_estimee[0]}</p>
-          )}
-        </div>
-        <div>
-          <label className="block font-semibold">Tarif</label>
-          <input
-            type="number"
-            name="tarif"
-            value={form.tarif}
-            onChange={handleChange}
-            className="w-full border p-2 rounded"
-          />
-          {errors.tarif && <p className="text-red-600 text-sm">{errors.tarif[0]}</p>}
-        </div>
-        <div>
-          <label className="block font-semibold">Statut</label>
-          <input
-            type="text"
-            name="statut"
-            value={form.statut}
-            onChange={handleChange}
-            className="w-full border p-2 rounded"
-          />
-          {errors.statut && <p className="text-red-600 text-sm">{errors.statut[0]}</p>}
-        </div>
         <div className="flex gap-4">
-          <button type="submit" className="admin-btn-primary">
-            {editingId ? "Mettre à jour" : "Ajouter"}
-          </button>
+          {editingId && (
+            <button type="submit" className="admin-btn-primary">
+              Mettre à jour
+            </button>
+          )}
           {editingId && (
             <button
               type="button"
@@ -278,12 +173,16 @@ export default function PrestationList() {
                 <td className="p-3">{p.prestataire_id}</td>
                 <td className="p-3">{p.client_id}</td>
                 <td className="p-3 space-x-2">
-                  <button onClick={() => startEdit(p)} className="text-yellow-600 hover:underline">
-                    Modifier
-                  </button>
-                  <button onClick={() => deletePrestation(p.id)} className="text-red-600 hover:underline">
-                    Supprimer
-                  </button>
+                  {!isEngagee(p) && (
+                    <>
+                      <button onClick={() => startEdit(p)} className="text-yellow-600 hover:underline">
+                        Modifier
+                      </button>
+                      <button onClick={() => deletePrestation(p.id)} className="text-red-600 hover:underline">
+                        Supprimer
+                      </button>
+                    </>
+                  )}
                 </td>
               </tr>
             ))}


### PR DESCRIPTION
## Summary
- block annonce creation by admins and prevent updates/deletes when engaged
- block modification/deletion of prestations once assigned or reserved
- remove admin ability to create annonces/prestations from backoffice
- limit admin edit forms to title/description
- hide edit/delete buttons when item already reserved/assigned

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68717bf0a78c8331aaf9fb780e55009a