### PR TITLE
Masque des formulaires tant qu'aucune édition

### DIFF
--- a/packages/frontend/backoffice/src/pages/admin/AnnoncesList.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/AnnoncesList.jsx
@@ -103,43 +103,39 @@ export default function AnnoncesList() {
         </p>
       )}
 
-      <form onSubmit={handleSubmit} className="bg-white shadow p-4 rounded space-y-4">
-        <h2 className="text-xl font-semibold">
-          {editingId ? "Modifier l'annonce" : "Sélectionner une annonce"}
-        </h2>
-        <div>
-          <label className="block font-semibold">Titre</label>
-          <input
-            type="text"
-            name="titre"
-            value={form.titre}
-            onChange={handleChange}
-            className="w-full border p-2 rounded"
-          />
-          {errors.titre && <p className="text-red-600 text-sm">{errors.titre[0]}</p>}
-        </div>
-        <div>
-          <label className="block font-semibold">Description</label>
-          <textarea
-            name="description"
-            value={form.description}
-            onChange={handleChange}
-            className="w-full border p-2 rounded"
-          />
-          {errors.description && (
-            <p className="text-red-600 text-sm">{errors.description[0]}</p>
-          )}
-        </div>
-        <div className="flex gap-4">
-          {editingId && (
+      {editingId && (
+        <form onSubmit={handleSubmit} className="bg-white shadow p-4 rounded space-y-4">
+          <h2 className="text-xl font-semibold">Modifier l'annonce</h2>
+          <div>
+            <label className="block font-semibold">Titre</label>
+            <input
+              type="text"
+              name="titre"
+              value={form.titre}
+              onChange={handleChange}
+              className="w-full border p-2 rounded"
+            />
+            {errors.titre && <p className="text-red-600 text-sm">{errors.titre[0]}</p>}
+          </div>
+          <div>
+            <label className="block font-semibold">Description</label>
+            <textarea
+              name="description"
+              value={form.description}
+              onChange={handleChange}
+              className="w-full border p-2 rounded"
+            />
+            {errors.description && (
+              <p className="text-red-600 text-sm">{errors.description[0]}</p>
+            )}
+          </div>
+          <div className="flex gap-4">
             <button
               type="submit"
               className="admin-btn-primary"
             >
               Mettre à jour
             </button>
-          )}
-          {editingId && (
             <button
               type="button"
               onClick={resetForm}
@@ -147,9 +143,9 @@ export default function AnnoncesList() {
             >
               Annuler
             </button>
-          )}
-        </div>
-      </form>
+          </div>
+        </form>
+      )}
 
       <div className="overflow-x-auto">
         <table className="min-w-full bg-white rounded shadow">

--- a/packages/frontend/backoffice/src/pages/admin/PrestationList.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/PrestationList.jsx
@@ -97,42 +97,38 @@ export default function PrestationList() {
         </p>
       )}
 
-      <form onSubmit={handleSubmit} className="bg-white shadow p-4 rounded space-y-4">
-        <h2 className="text-xl font-semibold">
-          {editingId ? "Modifier la prestation" : "Sélectionner une prestation"}
-        </h2>
-        <div>
-          <label className="block font-semibold">Type</label>
-          <input
-            type="text"
-            name="type_prestation"
-            value={form.type_prestation}
-            onChange={handleChange}
-            className="w-full border p-2 rounded"
-          />
-          {errors.type_prestation && (
-            <p className="text-red-600 text-sm">{errors.type_prestation[0]}</p>
-          )}
-        </div>
-        <div>
-          <label className="block font-semibold">Description</label>
-          <textarea
-            name="description"
-            value={form.description}
-            onChange={handleChange}
-            className="w-full border p-2 rounded"
-          />
-          {errors.description && (
-            <p className="text-red-600 text-sm">{errors.description[0]}</p>
-          )}
-        </div>
-        <div className="flex gap-4">
-          {editingId && (
+      {editingId && (
+        <form onSubmit={handleSubmit} className="bg-white shadow p-4 rounded space-y-4">
+          <h2 className="text-xl font-semibold">Modifier la prestation</h2>
+          <div>
+            <label className="block font-semibold">Type</label>
+            <input
+              type="text"
+              name="type_prestation"
+              value={form.type_prestation}
+              onChange={handleChange}
+              className="w-full border p-2 rounded"
+            />
+            {errors.type_prestation && (
+              <p className="text-red-600 text-sm">{errors.type_prestation[0]}</p>
+            )}
+          </div>
+          <div>
+            <label className="block font-semibold">Description</label>
+            <textarea
+              name="description"
+              value={form.description}
+              onChange={handleChange}
+              className="w-full border p-2 rounded"
+            />
+            {errors.description && (
+              <p className="text-red-600 text-sm">{errors.description[0]}</p>
+            )}
+          </div>
+          <div className="flex gap-4">
             <button type="submit" className="admin-btn-primary">
               Mettre à jour
             </button>
-          )}
-          {editingId && (
             <button
               type="button"
               onClick={resetForm}
@@ -140,9 +136,9 @@ export default function PrestationList() {
             >
               Annuler
             </button>
-          )}
-        </div>
-      </form>
+          </div>
+        </form>
+      )}
 
       <div className="overflow-x-auto">
         <table className="min-w-full bg-white rounded shadow">


### PR DESCRIPTION
## Summary
- hide annonce update form until editing
- hide prestation update form until editing

## Testing
- `npm run lint` in `packages/frontend/backoffice`
- `npm run lint` in `packages/frontend/frontoffice` *(fails: several lint errors)*
- `composer install` in `packages/backend` *(fails: stripe/stripe-php missing)*

------
https://chatgpt.com/codex/tasks/task_e_6871863cbb7c8331943e99ce29da9a4a