### PR TITLE
Fix admin edit/delete rules for prestations

### DIFF
--- a/packages/backend/app/Http/Controllers/PrestationController.php
+++ b/packages/backend/app/Http/Controllers/PrestationController.php
@@ -128,8 +128,9 @@ class PrestationController extends Controller
             return response()->json(['message' => 'Prestation introuvable.'], 404);
         }
 
-        if ($prestation->client_id !== null || $prestation->prestataire_id !== null) {
-            return response()->json(['message' => 'Impossible de modifier une prestation déjà réservée ou assignée.'], 403);
+        // Modification impossible dès qu'un client a réservé la prestation
+        if ($prestation->client_id !== null) {
+            return response()->json(['message' => 'Impossible de modifier une prestation déjà réservée par un client.'], 403);
         }
 
         $user = Auth::user();
@@ -167,8 +168,9 @@ class PrestationController extends Controller
             return response()->json(['message' => 'Suppression non autorisée.'], 403);
         }
 
-        if ($prestation->client_id !== null || $prestation->prestataire_id !== null) {
-            return response()->json(['message' => 'Impossible de supprimer une prestation déjà réservée ou assignée.'], 403);
+        // Suppression impossible dès qu'un client a réservé la prestation
+        if ($prestation->client_id !== null) {
+            return response()->json(['message' => 'Impossible de supprimer une prestation déjà réservée par un client.'], 403);
         }
 
         $prestation->delete();

--- a/packages/frontend/backoffice/src/pages/admin/PrestationList.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/PrestationList.jsx
@@ -68,9 +68,8 @@ export default function PrestationList() {
     }
   }
 
-  const isEngagee = (p) => {
-    return p.client_id || p.prestataire_id;
-  };
+  // A prestation is considered engaged only if a client has booked it
+  const isEngagee = (p) => p.client_id != null;
 
   const startEdit = (prestation) => {
     setEditingId(prestation.id);


### PR DESCRIPTION
## Summary
- allow admin to edit/delete a prestation only if no client booked it
- update frontend logic in PrestationList

## Testing
- `npm run lint` in `packages/frontend/backoffice`
- `composer install` *(fails: stripe/stripe-php constraint)*
- `composer update --no-interaction` *(fails: stripe/stripe-php constraint)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68718956a51483318de0db161750681c