### PR TITLE
Add entrypoint and TODO comments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,16 +5,16 @@ services:
     build: ./packages/backend
     container_name: backend
     ports:
-      - "8000:8000"
+      - "8000:8000" # TODO: changer ce port selon la config d’hébergement
     volumes:
-      - backend-storage:/app/storage
+      - backend-storage:/app/storage # TODO: sauvegarder ce volume en cas de déploiement sur serveur
     environment:
       DB_CONNECTION: pgsql
       DB_HOST: postgres
       DB_PORT: 5432
       DB_DATABASE: ecodeli_pa
       DB_USERNAME: postgres
-      DB_PASSWORD: ""
+      DB_PASSWORD: elliot # TODO: utiliser un mot de passe sécurisé en production
     depends_on:
       - postgres
     networks:
@@ -24,7 +24,7 @@ services:
     build: ./packages/frontend/frontoffice
     container_name: frontoffice
     ports:
-      - "4173:4173"
+      - "4173:4173" # TODO: ajuster ce port en production
     depends_on:
       - backend
     networks:
@@ -34,7 +34,7 @@ services:
     build: ./packages/frontend/backoffice
     container_name: backoffice
     ports:
-      - "4174:4174"
+      - "4174:4174" # TODO: ajuster ce port en production
     depends_on:
       - backend
     networks:

--- a/packages/backend/.env.production
+++ b/packages/backend/.env.production
@@ -1,14 +1,14 @@
 APP_NAME=EcoDeli
 APP_ENV=production
-APP_KEY=base64:CYz02DqJUFb5qOWmYLGqngyHCJMKt7A1yKlYnAPNql8= # TODO: régénérer une vraie clé avec 'php artisan key:generate' en prod
+APP_KEY=base64:CYz02DqJUFb5qOWmYLGqngyHCJMKt7A1yKlYnAPNql8= # TODO: régénérer avec php artisan key:generate en production
 APP_DEBUG=false
-APP_URL=http://localhost:8000 # TODO: remplacer par l'URL publique du backend
+APP_URL=http://localhost:8000 # TODO: mettre l’URL publique réelle du backend
 
 LOG_CHANNEL=stack
 LOG_LEVEL=warning
 
 DB_CONNECTION=pgsql
-DB_HOST=127.0.0.1 # TODO: remplacer par l'hôte PostgreSQL OVH en production
+DB_HOST=127.0.0.1 # TODO: remplacer par l’hôte PostgreSQL OVH si en production
 DB_PORT=5432
 DB_DATABASE=ecodeli_pa
 DB_USERNAME=postgres
@@ -22,10 +22,10 @@ QUEUE_CONNECTION=sync
 SESSION_DRIVER=file
 SESSION_LIFETIME=120
 
-SANCTUM_STATEFUL_DOMAINS=localhost:5173,localhost:6174 # TODO: ajuster avec les domaines frontoffice/backoffice en production
+SANCTUM_STATEFUL_DOMAINS=localhost:5173,localhost:6174 # TODO: mettre les domaines frontoffice/backoffice en production
 SESSION_DOMAIN=localhost
 
 STRIPE_PUBLIC_KEY=pk_test_51RdsclCoqQVCmYp35pDOWNNbqDg1ySdb6dXtRvf0DvlpQbyNzZdSBp9xIAouIoQ6loY2AicDN8qqfAURL87emPSt00uvAXLjWy # TODO: mettre la vraie clé Stripe live
-STRIPE_SECRET_KEY=sk_test_51RdsclCoqQVCmYp3r42ZB9CKTAP1mtAJkXfCsV3WRePgigsyluoC5oCnO0qo4VnvvGpZOX4CSMJoz8qzbhYETC9R00oly3mMWS
+STRIPE_SECRET_KEY=sk_test_51RdsclCoqQVCmYp3r42ZB9CKTAP1mtAJkXfCsV3WRePgigsyluoC5oCnO0qo4VnvvGpZOX4CSMJoz8qzbhYETC9R00oly3mMWS # TODO: mettre la vraie clé Stripe LIVE
 
 FRONTEND_URL=http://localhost:5173 # TODO: mettre l'URL publique du frontoffice

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -11,6 +11,8 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 WORKDIR /app
 COPY . .
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 # Prepare environment
 RUN cp .env.example .env && \
@@ -24,5 +26,7 @@ RUN composer install --no-interaction --prefer-dist && \
 # Fix permissions
 RUN chown -R www-data:www-data storage bootstrap/cache
 
-EXPOSE 8000
-CMD php artisan migrate --seed && php artisan serve --host=0.0.0.0 --port=8000
+EXPOSE 8000 # TODO: changer le port si le backend est derrière nginx ou un reverse proxy
+# TODO: en production, utiliser php-fpm + nginx au lieu de php artisan serve
+# TODO: en production, exécuter composer install --no-dev pour éviter les dépendances inutiles
+ENTRYPOINT ["/entrypoint.sh"]

--- a/packages/backend/entrypoint.sh
+++ b/packages/backend/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# TODO: Ce script attend que PostgreSQL soit prêt avant d’exécuter les migrations
+
+echo "Waiting for PostgreSQL at $DB_HOST:$DB_PORT..."
+
+until nc -z $DB_HOST $DB_PORT; do
+  sleep 1
+done
+
+echo "PostgreSQL is up – running migrations and starting Laravel..."
+
+php artisan migrate --seed
+php artisan serve --host=0.0.0.0 --port=8000

--- a/packages/frontend/backoffice/.env.production
+++ b/packages/frontend/backoffice/.env.production
@@ -1,1 +1,1 @@
-VITE_API_URL=http://localhost:8000/api # TODO: changer cette URL avec celle de l'API en production
+VITE_API_URL=http://localhost:8000/api # TODO: mettre l’URL réelle de l’API backend

--- a/packages/frontend/backoffice/Dockerfile
+++ b/packages/frontend/backoffice/Dockerfile
@@ -10,5 +10,6 @@ WORKDIR /app
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/package*.json ./
-EXPOSE 4173
+EXPOSE 4173 # TODO: adapter ce port si nécessaire dans l’environnement de production
+# TODO: utiliser npm ci --omit=dev en production pour éviter les packages de dev
 CMD ["npm", "run", "preview", "--", "--host", "0.0.0.0", "--port", "4174"]

--- a/packages/frontend/frontoffice/.env.production
+++ b/packages/frontend/frontoffice/.env.production
@@ -1,1 +1,1 @@
-VITE_API_URL=http://localhost:8000/api # TODO: changer cette URL avec celle de l'API en production
+VITE_API_URL=http://localhost:8000/api # TODO: mettre l’URL réelle de l’API backend

--- a/packages/frontend/frontoffice/Dockerfile
+++ b/packages/frontend/frontoffice/Dockerfile
@@ -10,5 +10,6 @@ WORKDIR /app
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/package*.json ./
-EXPOSE 4173
+EXPOSE 4173 # TODO: adapter ce port si nécessaire dans l’environnement de production
+# TODO: utiliser npm ci --omit=dev en production pour éviter les packages de dev
 CMD ["npm", "run", "preview", "--", "--host", "0.0.0.0", "--port", "4173"]


### PR DESCRIPTION
## Summary
- add entrypoint script to wait for PostgreSQL before running migrations
- reference the entrypoint in the Laravel Dockerfile and add TODO guidance
- document configurable ports and passwords in docker-compose
- update frontend Dockerfiles with TODO hints
- expand TODO comments in production env files

## Testing
- `php -v | head -n 1`
- `composer --version`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_68722be4de2c83319493547c83028fae