### PR TITLE
Fix backend migrations and Docker setup

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -15,7 +15,8 @@ COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # Prepare environment
-RUN cp .env.example .env && \
+RUN cp .env.production .env && \
+    # TODO: adapter le fichier .env en fonction de l'environnement de déploiement
     sed -i 's/DB_HOST=127.0.0.1/DB_HOST=postgres/' .env
 
 # Install PHP and JS dependencies and build assets

--- a/packages/backend/composer.json
+++ b/packages/backend/composer.json
@@ -12,7 +12,7 @@
         "laravel/framework": "^12.0",
         "laravel/sanctum": "^4.1",
         "laravel/tinker": "^2.10.1",
-        "stripe/stripe-php": "^11.15"
+        "stripe/stripe-php": "17.4.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/packages/backend/database/migrations/2025_05_05_152019_create_paiements_table.php
+++ b/packages/backend/database/migrations/2025_05_05_152019_create_paiements_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->id();
         
             $table->unsignedBigInteger('utilisateur_id'); // celui qui paie ou reçoit
-            $table->unsignedBigInteger('commande_id')->nullable(); // si rattaché à une commande
+            // $table->unsignedBigInteger('commande_id')->nullable(); // si rattaché à une commande
         
             $table->decimal('montant', 10, 2);
             $table->enum('sens', ['credit', 'debit']); // credit = reçoit, debit = paie
@@ -24,7 +24,6 @@ return new class extends Migration
             $table->timestamps();
         
             $table->foreign('utilisateur_id')->references('id')->on('utilisateurs')->onDelete('cascade');
-            $table->foreign('commande_id')->references('id')->on('commandes')->onDelete('set null');
         });
     }
 


### PR DESCRIPTION
## Summary
- avoid referencing non-existent `commande_id` in payments migration
- copy `.env.production` in Dockerfile for container setup
- pin `stripe/stripe-php` version to match composer lock

## Testing
- `composer validate --no-check-publish`
- `composer install --no-interaction --prefer-dist`
- `vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687230681cb88331aa7dc006fadf6c44