### PR TITLE
Add frontend search and role filters for UsersList

### DIFF
--- a/packages/frontend/backoffice/src/pages/admin/UsersList.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/UsersList.jsx
@@ -5,6 +5,8 @@ import api from "../../services/api";
 export default function UsersList() {
   const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [searchText, setSearchText] = useState("");
+  const [roleFilter, setRoleFilter] = useState("");
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -13,6 +15,16 @@ export default function UsersList() {
       .catch((err) => console.error(err))
       .finally(() => setLoading(false));
   }, []);
+
+  const filteredUsers = users.filter((u) => {
+    const term = searchText.toLowerCase();
+    const matchesText =
+      u.nom.toLowerCase().includes(term) ||
+      u.prenom.toLowerCase().includes(term) ||
+      u.email.toLowerCase().includes(term);
+    const matchesRole = roleFilter ? u.role === roleFilter : true;
+    return matchesText && matchesRole;
+  });
 
   if (loading) return <div className="p-4">Chargement...</div>;
 
@@ -36,6 +48,37 @@ export default function UsersList() {
         </div>
       </div>
 
+      <div className="flex flex-wrap items-end gap-4 mb-4">
+        <input
+          type="text"
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          placeholder="Rechercher..."
+          className="border p-2 rounded"
+        />
+        <select
+          value={roleFilter}
+          onChange={(e) => setRoleFilter(e.target.value)}
+          className="border p-2 rounded"
+        >
+          <option value="">Tous les rôles</option>
+          <option value="client">Client</option>
+          <option value="commercant">Commerçant</option>
+          <option value="livreur">Livreur</option>
+          <option value="prestataire">Prestataire</option>
+          <option value="admin">Admin</option>
+        </select>
+        <button
+          onClick={() => {
+            setSearchText("");
+            setRoleFilter("");
+          }}
+          className="admin-btn-secondary"
+        >
+          Réinitialiser les filtres
+        </button>
+      </div>
+
       <div className="overflow-x-auto">
         <table className="min-w-full bg-white rounded shadow">
           <thead>
@@ -50,7 +93,7 @@ export default function UsersList() {
             </tr>
           </thead>
           <tbody>
-            {users.map((user) => (
+            {filteredUsers.map((user) => (
               <tr key={user.id} className="border-b hover:bg-gray-50">
                 <td className="p-3">{user.nom}</td>
                 <td className="p-3">{user.prenom}</td>


### PR DESCRIPTION
## Summary
- add search/role filter state management
- derive filteredUsers based on search text and role
- display filter bar with search box, role select, and reset

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6872430b4a7883319cffda345af527e8