### PR TITLE
Fix search crash when user fields missing

### DIFF
--- a/packages/frontend/backoffice/src/pages/admin/UsersList.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/UsersList.jsx
@@ -19,9 +19,9 @@ export default function UsersList() {
   const filteredUsers = users.filter((u) => {
     const term = searchText.toLowerCase();
     const matchesText =
-      u.nom.toLowerCase().includes(term) ||
-      u.prenom.toLowerCase().includes(term) ||
-      u.email.toLowerCase().includes(term);
+      (u.nom || "").toLowerCase().includes(term) ||
+      (u.prenom || "").toLowerCase().includes(term) ||
+      (u.email || "").toLowerCase().includes(term);
     const matchesRole = roleFilter ? u.role === roleFilter : true;
     return matchesText && matchesRole;
   });


### PR DESCRIPTION
## Summary
- guard against null/undefined user fields during filtering in UsersList

## Testing
- `npm run lint` in `packages/frontend/backoffice`

------
https://chatgpt.com/codex/tasks/task_e_6872456cd06c8331a21caebadb531839