### PR TITLE
Add guest-only public pages

### DIFF
--- a/packages/frontend/frontoffice/src/components/Navbar.jsx
+++ b/packages/frontend/frontoffice/src/components/Navbar.jsx
@@ -112,10 +112,15 @@ export default function Navbar() {
 
           {!user ? (
             <>
-              {/* Liens prestations accessibles sans connexion */}
+              {/* Liens accessibles sans connexion */}
+              <li>
+                <Link to="/annonces-public" className="hover:text-lime-300 transition">
+                  Annonces
+                </Link>
+              </li>
               <li>
                 <Link
-                  to="/prestations/catalogue"
+                  to="/prestations/catalogue-public"
                   className="hover:text-lime-300 transition"
                 >
                   Prestations
@@ -270,10 +275,15 @@ export default function Navbar() {
             <li><Link to="/" className="block hover:text-lime-300">Accueil</Link></li>
             {!user ? (
               <>
-                {/* Liens prestations accessibles sans connexion */}
+                {/* Liens accessibles sans connexion */}
+                <li>
+                  <Link to="/annonces-public" className="block hover:text-lime-300">
+                    Annonces
+                  </Link>
+                </li>
                 <li>
                   <Link
-                    to="/prestations/catalogue"
+                    to="/prestations/catalogue-public"
                     className="block hover:text-lime-300"
                   >
                     Prestations

--- a/packages/frontend/frontoffice/src/components/PrestationCardPublic.jsx
+++ b/packages/frontend/frontoffice/src/components/PrestationCardPublic.jsx
@@ -1,0 +1,28 @@
+import { Link } from "react-router-dom";
+import PropTypes from "prop-types";
+import PrestationStatusBadge from "./PrestationStatusBadge";
+
+export default function PrestationCardPublic({ prestation }) {
+  return (
+    <div className="border rounded p-4 mb-4">
+      <h3 className="text-lg font-semibold">{prestation.type_prestation}</h3>
+      <p className="my-2">{prestation.description}</p>
+      <p>
+        Date : {new Date(prestation.date_heure).toLocaleString()} - Tarif: {prestation.tarif} €
+      </p>
+      <PrestationStatusBadge status={prestation.statut} />
+      {prestation.intervention && prestation.intervention.note !== null && (
+        <span className="ml-2 px-2 py-1 rounded bg-green-200 text-green-800 text-sm">
+          Évaluée
+        </span>
+      )}
+      <Link to={`/prestations/catalogue-public/${prestation.id}`} className="text-blue-600 underline">
+        Voir détail
+      </Link>
+    </div>
+  );
+}
+
+PrestationCardPublic.propTypes = {
+  prestation: PropTypes.object.isRequired,
+};

--- a/packages/frontend/frontoffice/src/pages/AnnonceDetailPublic.jsx
+++ b/packages/frontend/frontoffice/src/pages/AnnonceDetailPublic.jsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import api from "../services/api";
+
+export default function AnnonceDetailPublic() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [annonce, setAnnonce] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchAnnonce = async () => {
+      try {
+        const res = await api.get(`/public/annonces/${id}`);
+        setAnnonce(res.data);
+      } catch (err) {
+        console.error("Erreur chargement annonce :", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchAnnonce();
+  }, [id]);
+
+  const reserver = () => {
+    navigate("/register");
+  };
+
+  if (loading) return <p className="mt-10 text-center">Chargement...</p>;
+  if (!annonce) return <p className="mt-10 text-center">Annonce introuvable</p>;
+
+  return (
+    <div className="max-w-2xl mx-auto mt-10 p-6 bg-white shadow rounded">
+      <h2 className="text-2xl font-bold mb-4">{annonce.titre}</h2>
+      <p className="mb-2">{annonce.description}</p>
+      <p className="mb-2">
+        <strong>Prix :</strong> {annonce.prix_propose} €
+      </p>
+      <p className="mb-2">
+        <strong>Trajet :</strong> {annonce.entrepot_depart?.ville || "❓"} → {annonce.entrepot_arrivee?.ville || "❓"}
+      </p>
+      <button onClick={reserver} className="btn-primary mt-4">
+        Réserver
+      </button>
+    </div>
+  );
+}

--- a/packages/frontend/frontoffice/src/pages/AnnoncesPublic.jsx
+++ b/packages/frontend/frontoffice/src/pages/AnnoncesPublic.jsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import api from "../services/api";
+
+export default function AnnoncesPublic() {
+  const [annonces, setAnnonces] = useState([]);
+  const navigate = useNavigate();
+
+  const [searchText, setSearchText] = useState("");
+  const [minPrice, setMinPrice] = useState(null);
+  const [maxPrice, setMaxPrice] = useState(null);
+  const [dateDepart, setDateDepart] = useState(null);
+  const [dateArrivee, setDateArrivee] = useState(null);
+
+  useEffect(() => {
+    const fetchAnnonces = async () => {
+      try {
+        const res = await api.get("/public/annonces");
+        const annoncesFiltrees = res.data.filter((a) => a.type === "produit_livre");
+        setAnnonces(annoncesFiltrees);
+      } catch (error) {
+        console.error("Erreur lors du chargement des annonces :", error);
+      }
+    };
+
+    fetchAnnonces();
+  }, []);
+
+  const handleReset = () => {
+    setSearchText("");
+    setMinPrice(null);
+    setMaxPrice(null);
+    setDateDepart(null);
+    setDateArrivee(null);
+  };
+
+  const filteredAnnonces = annonces.filter((annonce) => {
+    const keyword = searchText.toLowerCase();
+
+    if (keyword) {
+      const inDesc = (annonce.description || "").toLowerCase().includes(keyword);
+      const inVille =
+        (annonce.entrepot_depart?.ville || "").toLowerCase().includes(keyword) ||
+        (annonce.entrepot_arrivee?.ville || "").toLowerCase().includes(keyword);
+      if (!(inDesc || inVille)) return false;
+    }
+
+    const price = Number(annonce.prix_propose);
+    if (minPrice !== null && price < minPrice) return false;
+    if (maxPrice !== null && price > maxPrice) return false;
+
+    if (dateDepart !== null && new Date(annonce.date_depart) < new Date(dateDepart)) {
+      return false;
+    }
+    if (dateArrivee !== null && new Date(annonce.date_arrivee) > new Date(dateArrivee)) {
+      return false;
+    }
+
+    return true;
+  });
+
+  return (
+    <div className="max-w-4xl mx-auto mt-8">
+      <h2 className="text-2xl font-bold mb-6">Annonces disponibles</h2>
+
+      <div className="flex flex-wrap items-end gap-4 mb-6">
+        <input
+          type="text"
+          placeholder="Rechercher..."
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          className="p-2 border rounded flex-1 min-w-[150px]"
+        />
+        <input
+          type="number"
+          placeholder="Prix min"
+          value={minPrice ?? ""}
+          onChange={(e) => setMinPrice(e.target.value === "" ? null : Number(e.target.value))}
+          className="p-2 border rounded w-28"
+        />
+        <input
+          type="number"
+          placeholder="Prix max"
+          value={maxPrice ?? ""}
+          onChange={(e) => setMaxPrice(e.target.value === "" ? null : Number(e.target.value))}
+          className="p-2 border rounded w-28"
+        />
+        <input
+          type="date"
+          value={dateDepart ?? ""}
+          onChange={(e) => setDateDepart(e.target.value === "" ? null : e.target.value)}
+          className="p-2 border rounded"
+        />
+        <input
+          type="date"
+          value={dateArrivee ?? ""}
+          onChange={(e) => setDateArrivee(e.target.value === "" ? null : e.target.value)}
+          className="p-2 border rounded"
+        />
+        <button onClick={handleReset} className="btn-secondary">
+          Réinitialiser les filtres
+        </button>
+      </div>
+
+      {filteredAnnonces.length === 0 ? (
+        <p>Aucune annonce disponible pour le moment.</p>
+      ) : (
+        <ul className="space-y-4">
+          {filteredAnnonces.map((annonce) => (
+            <li key={annonce.id} className="p-4 border rounded bg-white shadow">
+              <h3
+                onClick={() => navigate(`/annonces-public/${annonce.id}`)}
+                className="text-lg font-semibold text-blue-600 hover:underline cursor-pointer"
+              >
+                {annonce.titre}
+              </h3>
+              <p>{annonce.description}</p>
+              <p className="text-sm text-gray-500">
+                Prix : {annonce.prix_propose} € • Départ : {annonce.entrepot_depart?.ville || "❓"} → {annonce.entrepot_arrivee?.ville || "❓"}
+              </p>
+              <p className="text-xs text-gray-400">
+                Publié le : {new Date(annonce.created_at).toLocaleDateString()}
+              </p>
+
+              <button onClick={() => navigate(`/annonces-public/${annonce.id}`)} className="btn-primary mt-3">
+                Voir l'annonce
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/frontoffice/src/pages/CataloguePublic.jsx
+++ b/packages/frontend/frontoffice/src/pages/CataloguePublic.jsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+import api from "../services/api";
+import PrestationCardPublic from "../components/PrestationCardPublic";
+
+export default function CataloguePublic() {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await api.get("/public/prestations");
+        setData(res.data);
+      } catch (err) {
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  if (loading) return <p>Chargement...</p>;
+  if (error) return <p>Erreur lors du chargement.</p>;
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">Catalogue des prestations</h2>
+      {data && data.length > 0 ? (
+        data.map((p) => <PrestationCardPublic key={p.id} prestation={p} />)
+      ) : (
+        <p>Aucune prestation disponible.</p>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/frontoffice/src/pages/PrestationDetailPublic.jsx
+++ b/packages/frontend/frontoffice/src/pages/PrestationDetailPublic.jsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import api from "../services/api";
+import PrestationStatusBadge from "../components/PrestationStatusBadge";
+
+export default function PrestationDetailPublic() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [prestation, setPrestation] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const fetchPrestation = async () => {
+      try {
+        const res = await api.get(`/public/prestations/${id}`);
+        setPrestation(res.data);
+      } catch {
+        setError("Erreur lors du chargement.");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchPrestation();
+  }, [id]);
+
+  const payer = () => {
+    navigate("/register");
+  };
+
+  if (loading) return <p>Chargement...</p>;
+  if (error || !prestation) return <p>{error || "Prestation introuvable"}</p>;
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">Détail de la prestation</h2>
+      <p className="mb-2">{prestation.description}</p>
+      <div className="mb-2">
+        Statut : <PrestationStatusBadge status={prestation.statut} />
+      </div>
+      <button onClick={payer} className="bg-blue-500 text-white px-4 py-2 rounded">
+        Payer
+      </button>
+    </div>
+  );
+}

--- a/packages/frontend/frontoffice/src/routes/GuestRoute.jsx
+++ b/packages/frontend/frontoffice/src/routes/GuestRoute.jsx
@@ -1,0 +1,36 @@
+import { Navigate, useLocation } from "react-router-dom";
+import PropTypes from "prop-types";
+import { useAuth } from "../context/AuthContext";
+
+export default function GuestRoute({ children, redirectTo }) {
+  const { token, user } = useAuth();
+  const location = useLocation();
+
+  if (token || user) {
+    if (redirectTo) return <Navigate to={redirectTo} replace />;
+
+    // Fallback based on current path
+    if (location.pathname.startsWith("/annonces-public")) {
+      const parts = location.pathname.split("/");
+      if (parts.length > 2) {
+        return <Navigate to={`/annonces/${parts[2]}`} replace />;
+      }
+      return <Navigate to="/annonces" replace />;
+    }
+    if (location.pathname.startsWith("/prestations/catalogue-public")) {
+      const parts = location.pathname.split("/");
+      if (parts.length > 3) {
+        return <Navigate to={`/prestations/${parts[3]}`} replace />;
+      }
+      return <Navigate to="/prestations/catalogue" replace />;
+    }
+    return <Navigate to="/" replace />;
+  }
+
+  return children;
+}
+
+GuestRoute.propTypes = {
+  children: PropTypes.node.isRequired,
+  redirectTo: PropTypes.string,
+};

--- a/packages/frontend/frontoffice/src/routes/Router.jsx
+++ b/packages/frontend/frontoffice/src/routes/Router.jsx
@@ -12,6 +12,7 @@ import ChangePassword from "../pages/ChangePassword";
 import ResetPassword from "../pages/ResetPassword";
 import MainLayout from "../layouts/MainLayout";
 import PrivateRoute from "./PrivateRoute";
+import GuestRoute from "./GuestRoute";
 import Annonces from "../pages/Annonces";
 import CreerAnnonce from "../pages/CreerAnnonce";
 import AnnonceDetail from "../pages/AnnonceDetail";
@@ -28,6 +29,10 @@ import PublierPrestation from "../pages/PublierPrestation";
 import Notifications from "../pages/Notifications";
 import Catalogue from "../pages/Catalogue";
 import PrestationDetail from "../pages/PrestationDetail";
+import AnnoncesPublic from "../pages/AnnoncesPublic";
+import AnnonceDetailPublic from "../pages/AnnonceDetailPublic";
+import CataloguePublic from "../pages/CataloguePublic";
+import PrestationDetailPublic from "../pages/PrestationDetailPublic";
 import Prestations from "../pages/Prestations";
 import Disponibilites from "../pages/Disponibilites";
 import MesTrajets from "../pages/MesTrajets";
@@ -280,6 +285,38 @@ export default function AppRouter() {
           />
 
           <Route path="/prestations/catalogue" element={<Catalogue />} />
+          <Route
+            path="/annonces-public"
+            element={
+              <GuestRoute>
+                <AnnoncesPublic />
+              </GuestRoute>
+            }
+          />
+          <Route
+            path="/annonces-public/:id"
+            element={
+              <GuestRoute>
+                <AnnonceDetailPublic />
+              </GuestRoute>
+            }
+          />
+          <Route
+            path="/prestations/catalogue-public"
+            element={
+              <GuestRoute>
+                <CataloguePublic />
+              </GuestRoute>
+            }
+          />
+          <Route
+            path="/prestations/catalogue-public/:id"
+            element={
+              <GuestRoute>
+                <PrestationDetailPublic />
+              </GuestRoute>
+            }
+          />
 
           <Route
             path="/validation-code/:id"


### PR DESCRIPTION
## Summary
- add `GuestRoute` component for unauthenticated access
- create public pages to display annonces and prestations
- link to register when reserving or paying from public detail pages
- expose guest pages in the router
- show guest links in Navbar for visitors only

## Testing
- `npm run lint` *(fails: several existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68726f004ce083318993c4ab9f7f69a4