### PR TITLE
Fix data parsing in public listing pages

### DIFF
--- a/packages/frontend/frontoffice/src/pages/AnnoncesPublic.jsx
+++ b/packages/frontend/frontoffice/src/pages/AnnoncesPublic.jsx
@@ -16,7 +16,10 @@ export default function AnnoncesPublic() {
     const fetchAnnonces = async () => {
       try {
         const res = await api.get("/public/annonces");
-        const annoncesFiltrees = res.data.filter((a) => a.type === "produit_livre");
+        const annoncesArray = Array.isArray(res.data.data) ? res.data.data : [];
+        const annoncesFiltrees = annoncesArray.filter(
+          (a) => a.type === "produit_livre"
+        );
         setAnnonces(annoncesFiltrees);
       } catch (error) {
         console.error("Erreur lors du chargement des annonces :", error);

--- a/packages/frontend/frontoffice/src/pages/CataloguePublic.jsx
+++ b/packages/frontend/frontoffice/src/pages/CataloguePublic.jsx
@@ -17,7 +17,8 @@ export default function CataloguePublic() {
         if (res.headers["content-type"]) {
           console.log(res.headers["content-type"]);
         }
-        setData(res.data);
+        const prestationsArray = Array.isArray(res.data.data) ? res.data.data : [];
+        setData(prestationsArray);
       } catch (err) {
         setError(err);
       } finally {


### PR DESCRIPTION
## Summary
- fetch collections from `res.data.data` for public pages
- ensure arrays before filtering or mapping

## Testing
- `npm run lint` *(fails: cannot pass existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68728ca1467083319d70cca6b22ddd38