### PR TITLE
Allow prestataire re-upload without manual delete

### DIFF
--- a/packages/backend/app/Http/Controllers/JustificatifController.php
+++ b/packages/backend/app/Http/Controllers/JustificatifController.php
@@ -35,6 +35,16 @@ class JustificatifController extends Controller
             'type_document' => 'nullable|string',
         ]);
 
+        // Supprimer les justificatifs refusés existants
+        $anciens = JustificatifPrestataire::where('prestataire_id', $prestataire->id)
+            ->where('statut', 'refuse')
+            ->get();
+
+        foreach ($anciens as $ancien) {
+            Storage::disk('public')->delete($ancien->chemin);
+            $ancien->delete();
+        }
+
         $path = $request->file('fichier')->store(
             "justificatifs/prestataires/{$prestataire->id}",
             'public'

--- a/packages/frontend/frontoffice/src/pages/ProfilPrestataire.jsx
+++ b/packages/frontend/frontoffice/src/pages/ProfilPrestataire.jsx
@@ -55,13 +55,17 @@ export default function ProfilPrestataire() {
     const data = new FormData();
     data.append("fichier", newFile);
     try {
-      const res = await api.post("/prestataires/justificatifs", data, {
+      await api.post("/prestataires/justificatifs", data, {
         headers: {
           Authorization: `Bearer ${token}`,
           "Content-Type": "multipart/form-data",
         },
       });
-      setJustificatifs((prev) => [...prev, res.data]);
+
+      const list = await api.get("/prestataires/justificatifs", {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setJustificatifs(list.data);
 
       const profil = await api.get(`/prestataires/${user.id}`, {
         headers: { Authorization: `Bearer ${token}` },
@@ -165,14 +169,7 @@ export default function ProfilPrestataire() {
             </li>
           ))}
         </ul>
-        {prestataire.statut === "refuse" &&
-          justificatifs.some((j) => j.statut === "refuse") && (
-          <p className="text-sm text-gray-600">
-            📂 Vous devez supprimer les justificatifs refusés avant d’en ajouter
-            un nouveau.
-          </p>
-        )}
-        {prestataire.statut === "refuse" && justificatifs.length === 0 && (
+        {prestataire.statut === "refuse" && (
           <>
             <label className="block font-medium">Justificatif (RIB, RC Pro, etc.)</label>
             <input


### PR DESCRIPTION
## Summary
- auto-delete refused justificatifs before saving a new one
- refresh justificatif list after upload and always show upload input for refused prestataires

## Testing
- `composer install`
- `php artisan test --testsuite Feature` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_68728e93c5588331acc64857c496f987