### PR TITLE
Fix annonce public detail display

### DIFF
--- a/packages/backend/app/Http/Resources/AnnonceResource.php
+++ b/packages/backend/app/Http/Resources/AnnonceResource.php
@@ -3,6 +3,7 @@
 namespace App\Http\Resources;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Storage;
 
 class AnnonceResource extends JsonResource
 {
@@ -19,7 +20,7 @@ class AnnonceResource extends JsonResource
             'titre' => $this->titre,
             'description' => $this->description,
             'prix_propose' => $this->prix_propose,
-            'photo' => $this->photo,
+            'photo' => $this->photo ? Storage::url($this->photo) : null,
             'type' => $this->type,
             'entrepot_depart' => $this->entrepotDepart?->ville,
             'entrepot_arrivee' => $this->entrepotArrivee?->ville,

--- a/packages/frontend/frontoffice/src/pages/AnnonceDetailPublic.jsx
+++ b/packages/frontend/frontoffice/src/pages/AnnonceDetailPublic.jsx
@@ -12,7 +12,7 @@ export default function AnnonceDetailPublic() {
     const fetchAnnonce = async () => {
       try {
         const res = await api.get(`/public/annonces/${id}`);
-        setAnnonce(res.data);
+        setAnnonce(res.data.data);
       } catch (err) {
         console.error("Erreur chargement annonce :", err);
       } finally {
@@ -33,12 +33,19 @@ export default function AnnonceDetailPublic() {
   return (
     <div className="max-w-2xl mx-auto mt-10 p-6 bg-white shadow rounded">
       <h2 className="text-2xl font-bold mb-4">{annonce.titre}</h2>
+      {annonce.photo && (
+        <img
+          src={annonce.photo}
+          alt="Photo de l’annonce"
+          className="w-full max-w-md rounded-xl shadow mb-4"
+        />
+      )}
       <p className="mb-2">{annonce.description}</p>
       <p className="mb-2">
         <strong>Prix :</strong> {annonce.prix_propose} €
       </p>
       <p className="mb-2">
-        <strong>Trajet :</strong> {annonce.entrepot_depart?.ville || "❓"} → {annonce.entrepot_arrivee?.ville || "❓"}
+        <strong>Trajet :</strong> {annonce.entrepot_depart || "❓"} → {annonce.entrepot_arrivee || "❓"}
       </p>
       <button onClick={reserver} className="btn-primary mt-4">
         Réserver


### PR DESCRIPTION
## Summary
- fetch annonce detail correctly in React
- show annonce photo and cities
- serve annonse photo via Storage URL in backend

## Testing
- `npm run lint` *(fails: 6 errors, 8 warnings)*
- `php artisan test --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_6872935599bc833195f7eb6dc800257c