### PR TITLE
Fix paiementCallback user assignment

### DIFF
--- a/packages/backend/app/Http/Controllers/AnnonceController.php
+++ b/packages/backend/app/Http/Controllers/AnnonceController.php
@@ -447,10 +447,12 @@ class AnnonceController extends Controller
         if ($session && $session->payment_status === 'paid') {
             DB::transaction(function () use ($annonce, $sessionId) {
                 // Enregistrer le paiement s'il n'existe pas déjà
+                $utilisateurId = Auth::id() ?: $annonce->id_client ?: $annonce->id_commercant;
+
                 Paiement::firstOrCreate(
                     [
                         'annonce_id' => $annonce->id,
-                        'utilisateur_id' => $annonce->id_client,
+                        'utilisateur_id' => $utilisateurId,
                     ],
                     [
                         'montant' => $annonce->prix_propose,


### PR DESCRIPTION
## Summary
- ensure paiement callback uses the authenticated user when saving payment

## Testing
- `vendor/bin/phpunit`
- `npm run lint` *(fails: no-unused-vars and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6872ac62a084833198701b1015f6fa5f