### PR TITLE
Ensure annonce is assigned on payment

### DIFF
--- a/packages/backend/app/Http/Controllers/AnnonceController.php
+++ b/packages/backend/app/Http/Controllers/AnnonceController.php
@@ -463,6 +463,19 @@ class AnnonceController extends Controller
                     ]
                 );
 
+                if (
+                    $annonce->type === 'produit_livre' &&
+                    ! $annonce->id_client &&
+                    Auth::check() &&
+                    Auth::user()->role === 'client'
+                ) {
+                    $annonce->id_client = $utilisateurId;
+                    Log::info('Attribution automatique du client via paiementCallback', [
+                        'annonce_id' => $annonce->id,
+                        'utilisateur_id' => $utilisateurId,
+                    ]);
+                }
+
                 $annonce->is_paid = true;
                 $annonce->save();
 

--- a/packages/frontend/frontoffice/src/pages/PaiementSuccess.jsx
+++ b/packages/frontend/frontoffice/src/pages/PaiementSuccess.jsx
@@ -62,14 +62,28 @@ export default function PaiementSuccess() {
 
         if (!paiementOk) return;
 
-        if (context === "reserver" && annonceId && entrepotId) {
-          await api.post(
-            `/annonces/${annonceId}/reserver`,
-            { entrepot_arrivee_id: Number(entrepotId) },
-            { headers: { Authorization: `Bearer ${token}` } }
-          );
-          localStorage.removeItem("reservationEntrepot");
-          setMessage("Réservation confirmée !");
+        if (context === "reserver") {
+          if (!annonceId || !entrepotId || !token) {
+            console.error("Données manquantes pour la réservation", {
+              annonceId,
+              entrepotId,
+              token,
+            });
+            setMessage("Impossible de réserver l'annonce : informations manquantes.");
+          } else {
+            try {
+              await api.post(
+                `/annonces/${annonceId}/reserver`,
+                { entrepot_arrivee_id: Number(entrepotId) },
+                { headers: { Authorization: `Bearer ${token}` } }
+              );
+              localStorage.removeItem("reservationEntrepot");
+              setMessage("Réservation confirmée !");
+            } catch (err) {
+              console.error("Erreur lors de la réservation :", err);
+              setMessage("Erreur lors de la réservation de l'annonce.");
+            }
+          }
         } else if (context === "prestation_reserver" && prestationId) {
           setMessage("Prestation réservée !");
           localStorage.removeItem("prestationId");


### PR DESCRIPTION
## Summary
- improve reservation handling in `PaiementSuccess.jsx`
- assign `id_client` automatically in `paiementCallback`

## Testing
- `./vendor/bin/phpunit` *(fails: MissingAppKeyException)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6872aefd8d9883319e2e651b34589ce4