### PR TITLE
Fix payment fallback for Annonce

### DIFF
--- a/packages/backend/app/Http/Controllers/AnnonceController.php
+++ b/packages/backend/app/Http/Controllers/AnnonceController.php
@@ -447,17 +447,24 @@ class AnnonceController extends Controller
         if ($session && $session->payment_status === 'paid') {
             DB::transaction(function () use ($annonce, $sessionId) {
                 // Enregistrer le paiement s'il n'existe pas déjà
+                if (! $annonce->id_client) {
+                    Log::warning(
+                        'paiementCallback: id_client manquant, fallback sur Auth::id()',
+                        ['annonce_id' => $annonce->id]
+                    );
+                }
+
                 Paiement::firstOrCreate(
                     [
                         'annonce_id' => $annonce->id,
-                        'utilisateur_id' => $annonce->id_client,
+                        'utilisateur_id' => $annonce->id_client ?? Auth::id(),
                     ],
                     [
-                        'montant' => $annonce->prix_propose,
-                        'sens' => 'debit',
-                        'type' => 'stripe',
+                        'montant'   => $annonce->prix_propose,
+                        'sens'      => 'debit',
+                        'type'      => 'stripe',
                         'reference' => $sessionId,
-                        'statut' => 'valide',
+                        'statut'    => 'valide',
                     ]
                 );
 


### PR DESCRIPTION
## Summary
- make paiementCallback assign current user if annonce has no `id_client`
- log warning when this fallback happens

## Testing
- `composer install`
- `vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_68736e6e56dc833192fa5deda6e326ce