### PR TITLE
Check annoucement state before stripe session

### DIFF
--- a/packages/frontend/frontoffice/src/pages/ReserverAnnonce.jsx
+++ b/packages/frontend/frontoffice/src/pages/ReserverAnnonce.jsx
@@ -64,6 +64,14 @@ export default function ReserverAnnonce() {
     setLoading(true);
     setMessage("");
     try {
+      const res = await api.get(`/annonces/${annonceId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.data.id_client !== null || res.data.entrepot_arrivee_id !== null) {
+        setMessage("Cette annonce a déjà été réservée par un autre client.");
+        setLoading(false);
+        return;
+      }
       localStorage.setItem("reservationEntrepot", entrepotArriveeId);
       localStorage.setItem("paymentContext", "reserver");
       localStorage.setItem("reservationAnnonceId", annonceId);


### PR DESCRIPTION
## Summary
- prevent Stripe session creation if annonce already reserved
- ensure message is displayed when reservation isn't possible

## Testing
- `npm run lint` *(fails: err defined but never used in unrelated files)*
- `vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_6873725debdc8331b144dc8c36bd8322