### PR TITLE
Add route to reset annonce reservation

### DIFF
--- a/packages/backend/app/Http/Controllers/AnnonceController.php
+++ b/packages/backend/app/Http/Controllers/AnnonceController.php
@@ -527,4 +527,30 @@ class AnnonceController extends Controller
         return response()->json(['message' => 'Paiement enregistré avec succès.']);
     }
 
+    public function resetReservation($id)
+    {
+        $user = Auth::user();
+
+        if ($user->role !== 'admin') {
+            return response()->json(['message' => 'Action non autorisée.'], 403);
+        }
+
+        $annonce = Annonce::find($id);
+
+        if (! $annonce) {
+            return response()->json(['message' => 'Annonce introuvable.'], 404);
+        }
+
+        $annonce->id_client = null;
+        $annonce->entrepot_arrivee_id = null;
+        $annonce->save();
+
+        Log::info('Réinitialisation de réservation', [
+            'annonce_id' => $annonce->id,
+            'user_id' => $user->id,
+        ]);
+
+        return response()->json(['message' => 'Réservation réinitialisée avec succès.']);
+    }
+
 }

--- a/packages/backend/routes/api.php
+++ b/packages/backend/routes/api.php
@@ -156,6 +156,7 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::post('/annonces', [AnnonceController::class, 'store']);
     Route::patch('/annonces/{id}', [AnnonceController::class, 'update']);
     Route::delete('/annonces/{id}', [AnnonceController::class, 'destroy']);
+    Route::post('/annonces/{id}/reset-reservation', [AnnonceController::class, 'resetReservation']);
     
     // Commandes
     Route::get('/commandes', [CommandeController::class, 'index']);


### PR DESCRIPTION
## Summary
- allow admins to reset reservations on an annonce
- expose POST `/annonces/{id}/reset-reservation` endpoint

## Testing
- `composer install`
- `php artisan key:generate`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_687375546c508331a0dec568a908193d