### PR TITLE
Fix paiement callback method

### DIFF
--- a/packages/frontend/frontoffice/src/pages/PaiementSuccess.jsx
+++ b/packages/frontend/frontoffice/src/pages/PaiementSuccess.jsx
@@ -45,11 +45,10 @@ export default function PaiementSuccess() {
               { headers: { Authorization: `Bearer ${token}` } }
             );
 
-            await api.post(
-              `/annonces/${annonceId}/paiement-callback?session_id=${sessionId}`,
-              {},
-              { headers: { Authorization: `Bearer ${token}` } }
-            );
+            await api.get(`/annonces/${annonceId}/paiement-callback`, {
+              params: { session_id: sessionId },
+              headers: { Authorization: `Bearer ${token}` },
+            });
 
             localStorage.removeItem("reservationEntrepot");
             localStorage.removeItem("reservationAnnonceId");


### PR DESCRIPTION
## Summary
- fix HTTP method for reservation payment callback

## Testing
- `npm run lint` *(fails: 13 problems (5 errors, 8 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68737758b65483318c668e68063717f6