### PR TITLE
Add public guest pages and routes

### DIFF
--- a/packages/frontend/frontoffice/src/components/Navbar.jsx
+++ b/packages/frontend/frontoffice/src/components/Navbar.jsx
@@ -112,10 +112,18 @@ export default function Navbar() {
 
           {!user ? (
             <>
-              {/* Liens prestations accessibles sans connexion */}
+              {/* Liens vitrine accessibles sans connexion */}
               <li>
                 <Link
-                  to="/prestations/catalogue"
+                  to="/annonces-public"
+                  className="hover:text-lime-300 transition"
+                >
+                  Annonces
+                </Link>
+              </li>
+              <li>
+                <Link
+                  to="/catalogue-public"
                   className="hover:text-lime-300 transition"
                 >
                   Prestations
@@ -270,10 +278,18 @@ export default function Navbar() {
             <li><Link to="/" className="block hover:text-lime-300">Accueil</Link></li>
             {!user ? (
               <>
-                {/* Liens prestations accessibles sans connexion */}
+                {/* Liens vitrine accessibles sans connexion */}
                 <li>
                   <Link
-                    to="/prestations/catalogue"
+                    to="/annonces-public"
+                    className="block hover:text-lime-300"
+                  >
+                    Annonces
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    to="/catalogue-public"
                     className="block hover:text-lime-300"
                   >
                     Prestations

--- a/packages/frontend/frontoffice/src/pages/AnnonceDetailPublic.jsx
+++ b/packages/frontend/frontoffice/src/pages/AnnonceDetailPublic.jsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import api from "../services/api";
+
+export default function AnnonceDetailPublic() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [annonce, setAnnonce] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchAnnonce = async () => {
+      try {
+        const res = await api.get(`/public/annonces/${id}`);
+        setAnnonce(res.data);
+      } catch (err) {
+        console.error("Erreur chargement annonce:", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchAnnonce();
+  }, [id]);
+
+  if (loading) return <p className="mt-10 text-center">Chargement...</p>;
+  if (!annonce) return <p className="mt-10 text-center">Annonce introuvable</p>;
+
+  return (
+    <div className="max-w-2xl mx-auto mt-10 p-6 bg-white shadow rounded">
+      <h2 className="text-2xl font-bold mb-4">{annonce.titre}</h2>
+      <p className="mb-2">{annonce.description}</p>
+      <p className="mb-2">
+        <strong>Prix :</strong> {annonce.prix_propose} €
+      </p>
+      <p className="mb-2">
+        <strong>Trajet :</strong> {annonce.entrepot_depart?.ville || "❓"} → {" "}
+        {annonce.entrepot_arrivee?.ville || "❓"}
+      </p>
+      <button onClick={() => navigate("/register")} className="btn-primary mt-4">
+        Réserver
+      </button>
+    </div>
+  );
+}

--- a/packages/frontend/frontoffice/src/pages/AnnoncesPublic.jsx
+++ b/packages/frontend/frontoffice/src/pages/AnnoncesPublic.jsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import api from "../services/api";
+
+export default function AnnoncesPublic() {
+  const [annonces, setAnnonces] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchAnnonces = async () => {
+      try {
+        const res = await api.get("/public/annonces");
+        const annoncesFiltrees = res.data.filter(
+          (a) => a.type === "produit_livre"
+        );
+        setAnnonces(annoncesFiltrees);
+      } catch (err) {
+        console.error("Erreur chargement annonces:", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchAnnonces();
+  }, []);
+
+  if (loading) return <p>Chargement...</p>;
+
+  return (
+    <div className="max-w-4xl mx-auto mt-8">
+      <h2 className="text-2xl font-bold mb-6">Annonces publiques</h2>
+      {annonces.length === 0 ? (
+        <p>Aucune annonce disponible.</p>
+      ) : (
+        <ul className="space-y-4">
+          {annonces.map((annonce) => (
+            <li
+              key={annonce.id}
+              className="p-4 border rounded bg-white shadow"
+            >
+              <h3
+                onClick={() => navigate(`/annonces-public/${annonce.id}`)}
+                className="text-lg font-semibold text-blue-600 hover:underline cursor-pointer"
+              >
+                {annonce.titre}
+              </h3>
+              <p>{annonce.description}</p>
+              <p className="text-sm text-gray-500">
+                Prix : {annonce.prix_propose} € • Départ :
+                {" "}
+                {annonce.entrepot_depart?.ville || "❓"} → {" "}
+                {annonce.entrepot_arrivee?.ville || "❓"}
+              </p>
+              <p className="text-xs text-gray-400">
+                Publié le : {new Date(annonce.created_at).toLocaleDateString()}
+              </p>
+              <button
+                onClick={() => navigate(`/annonces-public/${annonce.id}`)}
+                className="btn-primary mt-3"
+              >
+                Voir l'annonce
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/frontoffice/src/pages/CataloguePublic.jsx
+++ b/packages/frontend/frontoffice/src/pages/CataloguePublic.jsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import api from "../services/api";
+import PrestationStatusBadge from "../components/PrestationStatusBadge";
+
+export default function CataloguePublic() {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await api.get("/public/prestations");
+        setData(res.data);
+      } catch (err) {
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  if (loading) return <p>Chargement...</p>;
+  if (error) return <p>Erreur lors du chargement.</p>;
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">Catalogue des prestations</h2>
+      {data && data.length > 0 ? (
+        data.map((p) => (
+          <div key={p.id} className="border rounded p-4 mb-4">
+            <h3 className="text-lg font-semibold">{p.type_prestation}</h3>
+            <p className="my-2">{p.description}</p>
+            <p>
+              Date : {new Date(p.date_heure).toLocaleString()} - Tarif: {p.tarif} €
+            </p>
+            <PrestationStatusBadge status={p.statut} />
+            {p.intervention && p.intervention.note !== null && (
+              <span className="ml-2 px-2 py-1 rounded bg-green-200 text-green-800 text-sm">
+                Évaluée
+              </span>
+            )}
+            <button
+              onClick={() => navigate(`/catalogue-public/${p.id}`)}
+              className="text-blue-600 underline mt-2"
+            >
+              Voir détail
+            </button>
+          </div>
+        ))
+      ) : (
+        <p>Aucune prestation disponible.</p>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/frontoffice/src/pages/PrestationDetailPublic.jsx
+++ b/packages/frontend/frontoffice/src/pages/PrestationDetailPublic.jsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import api from "../services/api";
+import PrestationStatusBadge from "../components/PrestationStatusBadge";
+
+export default function PrestationDetailPublic() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [prestation, setPrestation] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchPrestation = async () => {
+      try {
+        const res = await api.get(`/public/prestations/${id}`);
+        setPrestation(res.data);
+      } catch (err) {
+        setError(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchPrestation();
+  }, [id]);
+
+  if (loading) return <p>Chargement...</p>;
+  if (error) return <p>Erreur lors du chargement.</p>;
+  if (!prestation) return <p>Prestation introuvable.</p>;
+
+  return (
+    <div>
+      <h2 className="text-xl font-bold mb-4">Détail de la prestation</h2>
+      <p className="mb-2">{prestation.description}</p>
+      <p className="mb-2">
+        Date : {new Date(prestation.date_heure).toLocaleString()} - Tarif:
+        {" "}
+        {prestation.tarif} €
+      </p>
+      <PrestationStatusBadge status={prestation.statut} />
+      {prestation.intervention && prestation.intervention.note !== null && (
+        <span className="ml-2 px-2 py-1 rounded bg-green-200 text-green-800 text-sm">
+          Évaluée
+        </span>
+      )}
+      <button onClick={() => navigate("/register")} className="btn-primary mt-4">
+        Payer
+      </button>
+    </div>
+  );
+}

--- a/packages/frontend/frontoffice/src/routes/GuestRoute.jsx
+++ b/packages/frontend/frontoffice/src/routes/GuestRoute.jsx
@@ -1,0 +1,13 @@
+import { Navigate } from "react-router-dom";
+import PropTypes from "prop-types";
+import { useAuth } from "../context/AuthContext";
+
+export default function GuestRoute({ children }) {
+  const { user, token } = useAuth();
+
+  return user || token ? <Navigate to="/" replace /> : children;
+}
+
+GuestRoute.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/packages/frontend/frontoffice/src/routes/Router.jsx
+++ b/packages/frontend/frontoffice/src/routes/Router.jsx
@@ -35,6 +35,11 @@ import ValidationCodeBox from "../pages/ValidationCodeBox";
 import SuiviAnnonce from "../pages/SuiviAnnonce";
 import ReserverAnnonce from "../pages/ReserverAnnonce";
 import MesPaiements from "../pages/client/MesPaiements";
+import GuestRoute from "./GuestRoute";
+import AnnoncesPublic from "../pages/AnnoncesPublic";
+import AnnonceDetailPublic from "../pages/AnnonceDetailPublic";
+import CataloguePublic from "../pages/CataloguePublic";
+import PrestationDetailPublic from "../pages/PrestationDetailPublic";
 
 export default function AppRouter() {
   return (
@@ -49,6 +54,38 @@ export default function AppRouter() {
           <Route
             path="/register-prestataire"
             element={<RegisterPrestataire />}
+          />
+          <Route
+            path="/annonces-public"
+            element={
+              <GuestRoute>
+                <AnnoncesPublic />
+              </GuestRoute>
+            }
+          />
+          <Route
+            path="/annonces-public/:id"
+            element={
+              <GuestRoute>
+                <AnnonceDetailPublic />
+              </GuestRoute>
+            }
+          />
+          <Route
+            path="/catalogue-public"
+            element={
+              <GuestRoute>
+                <CataloguePublic />
+              </GuestRoute>
+            }
+          />
+          <Route
+            path="/catalogue-public/:id"
+            element={
+              <GuestRoute>
+                <PrestationDetailPublic />
+              </GuestRoute>
+            }
           />
           <Route
             path="/annonces"


### PR DESCRIPTION
## Summary
- add GuestRoute component to block logged-in users from public pages
- implement public pages for announcements and prestations
- expose new guest routes in router
- update navbar links for visitors

## Testing
- `npm run lint` *(fails: ERR_MODULE_NOT_FOUND: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68737b28f4d88331888bac0b91cf140c