### PR TITLE
Expose public endpoints for annonces and prestations

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -16,6 +16,16 @@ All routes are prefixed with `/api` when served by Laravel. Authentication uses 
 ### Logout
 | POST | `/logout` | `AuthController@logout` | Revoke current token. | `auth:sanctum` | 200 |
 
+## Public Routes
+Routes accessible without authentication.
+
+| Method | URL | Controller@method | Description |
+|-------|-----|-----------------|-------------|
+| GET | `/public/annonces` | `PublicController@listAnnonces` | List public product adverts |
+| GET | `/public/annonces/{id}` | `PublicController@showAnnonce` | Show specific public advert |
+| GET | `/public/prestations` | `PublicController@listPrestations` | List available services |
+| GET | `/public/prestations/{id}` | `PublicController@showPrestation` | Show service detail |
+
 ## Admin Routes
 Middleware: `auth:sanctum`, `role:admin`
 

--- a/packages/backend/app/Http/Controllers/PublicController.php
+++ b/packages/backend/app/Http/Controllers/PublicController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Annonce;
+use App\Models\Prestation;
+use App\Http\Resources\AnnonceResource;
+use App\Http\Resources\PrestationResource;
+
+class PublicController extends Controller
+{
+    public function listAnnonces()
+    {
+        $annonces = Annonce::with(['entrepotDepart', 'entrepotArrivee'])
+            ->where('type', 'produit_livre')
+            ->orderBy('created_at', 'desc')
+            ->get();
+
+        return AnnonceResource::collection($annonces);
+    }
+
+    public function showAnnonce($id)
+    {
+        $annonce = Annonce::with(['entrepotDepart', 'entrepotArrivee'])
+            ->where('type', 'produit_livre')
+            ->find($id);
+
+        if (! $annonce) {
+            return response()->json(['message' => 'Annonce introuvable.'], 404);
+        }
+
+        return new AnnonceResource($annonce);
+    }
+
+    public function listPrestations()
+    {
+        $prestations = Prestation::with('intervention')
+            ->whereNull('client_id')
+            ->where('statut', 'disponible')
+            ->orderBy('date_heure', 'asc')
+            ->get();
+
+        return PrestationResource::collection($prestations);
+    }
+
+    public function showPrestation($id)
+    {
+        $prestation = Prestation::with('intervention')->find($id);
+
+        if (! $prestation) {
+            return response()->json(['message' => 'Prestation introuvable.'], 404);
+        }
+
+        return new PrestationResource($prestation);
+    }
+}

--- a/packages/backend/app/Http/Resources/AnnonceResource.php
+++ b/packages/backend/app/Http/Resources/AnnonceResource.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class AnnonceResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'type' => $this->type,
+            'titre' => $this->titre,
+            'description' => $this->description,
+            'prix_propose' => $this->prix_propose,
+            'photo' => $this->photo,
+            'entrepot_depart' => $this->whenLoaded('entrepotDepart'),
+            'entrepot_arrivee' => $this->whenLoaded('entrepotArrivee'),
+            'statut' => $this->statut,
+            'created_at' => $this->created_at,
+        ];
+    }
+}

--- a/packages/backend/app/Http/Resources/PrestationResource.php
+++ b/packages/backend/app/Http/Resources/PrestationResource.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PrestationResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'type_prestation' => $this->type_prestation,
+            'description' => $this->description,
+            'date_heure' => $this->date_heure,
+            'duree_estimee' => $this->duree_estimee,
+            'tarif' => $this->tarif,
+            'statut' => $this->statut,
+            'intervention' => $this->whenLoaded('intervention'),
+            'created_at' => $this->created_at,
+        ];
+    }
+}

--- a/packages/backend/routes/api.php
+++ b/packages/backend/routes/api.php
@@ -32,6 +32,7 @@ use App\Http\Controllers\StatAdminController;
 use App\Http\Controllers\Api\EmailVerificationController;
 use Laravel\Fortify\Http\Controllers\EmailVerificationNotificationController;
 use App\Http\Controllers\TrajetLivreurController;
+use App\Http\Controllers\PublicController;
 
 // Authentification
 Route::post('/login', [AuthController::class, 'login']);
@@ -41,6 +42,14 @@ Route::post('/register', [AuthController::class, 'register']);
 Route::get('/verify-email/{id}/{hash}', [EmailVerificationController::class, 'verify'])
     ->middleware('signed')
     ->name('verification.verify');
+
+// Routes publiques sans authentification
+Route::prefix('public')->group(function () {
+    Route::get('/annonces', [PublicController::class, 'listAnnonces']);
+    Route::get('/annonces/{id}', [PublicController::class, 'showAnnonce']);
+    Route::get('/prestations', [PublicController::class, 'listPrestations']);
+    Route::get('/prestations/{id}', [PublicController::class, 'showPrestation']);
+});
 
 // ADMIN uniquement
 Route::middleware(['auth:sanctum', 'role:admin'])->group(function () {


### PR DESCRIPTION
## Summary
- add `PublicController` with read-only endpoints
- create `AnnonceResource` and `PrestationResource`
- register public routes in API
- document new endpoints in `docs/api.md`

## Testing
- `composer install`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687381583b7c83319992ddbab37a2512