### PR TITLE
Fix public components

### DIFF
--- a/packages/backend/app/Http/Controllers/PublicController.php
+++ b/packages/backend/app/Http/Controllers/PublicController.php
@@ -13,6 +13,7 @@ class PublicController extends Controller
     {
         $annonces = Annonce::with(['entrepotDepart', 'entrepotArrivee'])
             ->where('type', 'produit_livre')
+            ->whereNull('id_client')
             ->orderBy('created_at', 'desc')
             ->get();
 

--- a/packages/frontend/frontoffice/src/pages/AnnonceDetailPublic.jsx
+++ b/packages/frontend/frontoffice/src/pages/AnnonceDetailPublic.jsx
@@ -7,14 +7,16 @@ export default function AnnonceDetailPublic() {
   const navigate = useNavigate();
   const [annonce, setAnnonce] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     const fetchAnnonce = async () => {
       try {
         const res = await api.get(`/public/annonces/${id}`);
-        setAnnonce(res.data);
+        setAnnonce(res.data.data);
       } catch (err) {
         console.error("Erreur chargement annonce:", err);
+        setError(err);
       } finally {
         setLoading(false);
       }
@@ -23,6 +25,7 @@ export default function AnnonceDetailPublic() {
   }, [id]);
 
   if (loading) return <p className="mt-10 text-center">Chargement...</p>;
+  if (error) return <p className="mt-10 text-center">Erreur lors du chargement.</p>;
   if (!annonce) return <p className="mt-10 text-center">Annonce introuvable</p>;
 
   return (

--- a/packages/frontend/frontoffice/src/pages/CataloguePublic.jsx
+++ b/packages/frontend/frontoffice/src/pages/CataloguePublic.jsx
@@ -13,7 +13,7 @@ export default function CataloguePublic() {
     const fetchData = async () => {
       try {
         const res = await api.get("/public/prestations");
-        setData(res.data);
+        setData(res.data.data);
       } catch (err) {
         setError(err);
       } finally {

--- a/packages/frontend/frontoffice/src/pages/PrestationDetailPublic.jsx
+++ b/packages/frontend/frontoffice/src/pages/PrestationDetailPublic.jsx
@@ -14,7 +14,7 @@ export default function PrestationDetailPublic() {
     const fetchPrestation = async () => {
       try {
         const res = await api.get(`/public/prestations/${id}`);
-        setPrestation(res.data);
+        setPrestation(res.data.data);
       } catch (err) {
         setError(err);
       } finally {


### PR DESCRIPTION
## Summary
- fix frontend public components to read `res.data.data`
- show errors in `AnnonceDetailPublic`
- filter reserved annonces on the backend

## Testing
- `./vendor/bin/phpunit tests`
- `npx eslint src/pages/AnnonceDetailPublic.jsx src/pages/CataloguePublic.jsx src/pages/PrestationDetailPublic.jsx`


------
https://chatgpt.com/codex/tasks/task_e_687388268f5883318e7eadf17d15c4f3