### PR TITLE
Add search filters to public lists

### DIFF
--- a/packages/frontend/frontoffice/src/pages/AnnoncesPublic.jsx
+++ b/packages/frontend/frontoffice/src/pages/AnnoncesPublic.jsx
@@ -6,6 +6,11 @@ export default function AnnoncesPublic() {
   const [annonces, setAnnonces] = useState([]);
   const [loading, setLoading] = useState(true);
   const navigate = useNavigate();
+  const [searchText, setSearchText] = useState("");
+  const [minPrice, setMinPrice] = useState(null);
+  const [maxPrice, setMaxPrice] = useState(null);
+  const [dateDepart, setDateDepart] = useState(null);
+  const [dateArrivee, setDateArrivee] = useState(null);
 
   useEffect(() => {
     const fetchAnnonces = async () => {
@@ -22,16 +27,97 @@ export default function AnnoncesPublic() {
     fetchAnnonces();
   }, []);
 
+  const handleReset = () => {
+    setSearchText("");
+    setMinPrice(null);
+    setMaxPrice(null);
+    setDateDepart(null);
+    setDateArrivee(null);
+  };
+
+  const filteredAnnonces = annonces.filter((annonce) => {
+    const keyword = searchText.toLowerCase();
+
+    if (keyword) {
+      const inDesc = (annonce.description || "").toLowerCase().includes(keyword);
+      const inVille =
+        (annonce.entrepot_depart?.ville || "").toLowerCase().includes(keyword) ||
+        (annonce.entrepot_arrivee?.ville || "").toLowerCase().includes(keyword);
+      if (!(inDesc || inVille)) return false;
+    }
+
+    const price = Number(annonce.prix_propose);
+    if (minPrice !== null && price < minPrice) return false;
+    if (maxPrice !== null && price > maxPrice) return false;
+
+    if (dateDepart !== null && new Date(annonce.date_depart) < new Date(dateDepart)) {
+      return false;
+    }
+    if (dateArrivee !== null && new Date(annonce.date_arrivee) > new Date(dateArrivee)) {
+      return false;
+    }
+
+    return true;
+  });
+
   if (loading) return <p>Chargement...</p>;
 
   return (
     <div className="max-w-4xl mx-auto mt-8">
       <h2 className="text-2xl font-bold mb-6">Annonces</h2>
-      {annonces.length === 0 ? (
+
+      <div className="flex flex-wrap items-end gap-4 mb-6">
+        <input
+          type="text"
+          placeholder="Rechercher..."
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          className="p-2 border rounded flex-1 min-w-[150px]"
+        />
+        <input
+          type="number"
+          placeholder="Prix min"
+          value={minPrice ?? ""}
+          onChange={(e) =>
+            setMinPrice(e.target.value === "" ? null : Number(e.target.value))
+          }
+          className="p-2 border rounded w-28"
+        />
+        <input
+          type="number"
+          placeholder="Prix max"
+          value={maxPrice ?? ""}
+          onChange={(e) =>
+            setMaxPrice(e.target.value === "" ? null : Number(e.target.value))
+          }
+          className="p-2 border rounded w-28"
+        />
+        <input
+          type="date"
+          value={dateDepart ?? ""}
+          onChange={(e) =>
+            setDateDepart(e.target.value === "" ? null : e.target.value)
+          }
+          className="p-2 border rounded"
+        />
+        <input
+          type="date"
+          value={dateArrivee ?? ""}
+          onChange={(e) =>
+            setDateArrivee(e.target.value === "" ? null : e.target.value)
+          }
+          className="p-2 border rounded"
+        />
+        <button onClick={handleReset} className="btn-secondary">
+          Réinitialiser les filtres
+        </button>
+      </div>
+
+      {filteredAnnonces.length === 0 ? (
         <p>Aucune annonce disponible.</p>
       ) : (
         <ul className="space-y-4">
-          {annonces.map((annonce) => (
+          {filteredAnnonces.map((annonce) => (
             <li
               key={annonce.id}
               className="p-4 border rounded bg-white shadow"

--- a/packages/frontend/frontoffice/src/pages/Catalogue.jsx
+++ b/packages/frontend/frontoffice/src/pages/Catalogue.jsx
@@ -9,6 +9,11 @@ export default function Catalogue() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const { token } = useAuth();
+  const [searchText, setSearchText] = useState("");
+  const [minPrice, setMinPrice] = useState(null);
+  const [maxPrice, setMaxPrice] = useState(null);
+  const [dateDepart, setDateDepart] = useState(null);
+  const [dateArrivee, setDateArrivee] = useState(null);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -30,11 +35,90 @@ export default function Catalogue() {
   if (loading) return <p>Chargement...</p>;
   if (error) return <p>Erreur lors du chargement.</p>;
 
+  const handleReset = () => {
+    setSearchText("");
+    setMinPrice(null);
+    setMaxPrice(null);
+    setDateDepart(null);
+    setDateArrivee(null);
+  };
+
+  const filteredData = data.filter((p) => {
+    const keyword = searchText.toLowerCase();
+
+    if (keyword) {
+      const inDesc = (p.description || "").toLowerCase().includes(keyword);
+      const inType = (p.type_prestation || "").toLowerCase().includes(keyword);
+      if (!(inDesc || inType)) return false;
+    }
+
+    const price = Number(p.tarif);
+    if (minPrice !== null && price < minPrice) return false;
+    if (maxPrice !== null && price > maxPrice) return false;
+
+    if (dateDepart !== null && new Date(p.date_heure) < new Date(dateDepart)) {
+      return false;
+    }
+    if (dateArrivee !== null && new Date(p.date_heure) > new Date(dateArrivee)) {
+      return false;
+    }
+
+    return true;
+  });
+
   return (
-    <div>
+    <div className="max-w-4xl mx-auto mt-8">
       <h2 className="text-xl font-bold mb-4">Catalogue des prestations</h2>
-      {data && data.length > 0 ? (
-        data.map((p) => <PrestationCard key={p.id} prestation={p} />)
+
+      <div className="flex flex-wrap items-end gap-4 mb-6">
+        <input
+          type="text"
+          placeholder="Rechercher..."
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          className="p-2 border rounded flex-1 min-w-[150px]"
+        />
+        <input
+          type="number"
+          placeholder="Prix min"
+          value={minPrice ?? ""}
+          onChange={(e) =>
+            setMinPrice(e.target.value === "" ? null : Number(e.target.value))
+          }
+          className="p-2 border rounded w-28"
+        />
+        <input
+          type="number"
+          placeholder="Prix max"
+          value={maxPrice ?? ""}
+          onChange={(e) =>
+            setMaxPrice(e.target.value === "" ? null : Number(e.target.value))
+          }
+          className="p-2 border rounded w-28"
+        />
+        <input
+          type="date"
+          value={dateDepart ?? ""}
+          onChange={(e) =>
+            setDateDepart(e.target.value === "" ? null : e.target.value)
+          }
+          className="p-2 border rounded"
+        />
+        <input
+          type="date"
+          value={dateArrivee ?? ""}
+          onChange={(e) =>
+            setDateArrivee(e.target.value === "" ? null : e.target.value)
+          }
+          className="p-2 border rounded"
+        />
+        <button onClick={handleReset} className="btn-secondary">
+          Réinitialiser les filtres
+        </button>
+      </div>
+
+      {filteredData.length > 0 ? (
+        filteredData.map((p) => <PrestationCard key={p.id} prestation={p} />)
       ) : (
         <p>Aucune prestation disponible.</p>
       )}

--- a/packages/frontend/frontoffice/src/pages/CataloguePublic.jsx
+++ b/packages/frontend/frontoffice/src/pages/CataloguePublic.jsx
@@ -8,6 +8,11 @@ export default function CataloguePublic() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const navigate = useNavigate();
+  const [searchText, setSearchText] = useState("");
+  const [minPrice, setMinPrice] = useState(null);
+  const [maxPrice, setMaxPrice] = useState(null);
+  const [dateDepart, setDateDepart] = useState(null);
+  const [dateArrivee, setDateArrivee] = useState(null);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -26,11 +31,90 @@ export default function CataloguePublic() {
   if (loading) return <p>Chargement...</p>;
   if (error) return <p>Erreur lors du chargement.</p>;
 
+  const handleReset = () => {
+    setSearchText("");
+    setMinPrice(null);
+    setMaxPrice(null);
+    setDateDepart(null);
+    setDateArrivee(null);
+  };
+
+  const filteredData = data.filter((p) => {
+    const keyword = searchText.toLowerCase();
+
+    if (keyword) {
+      const inDesc = (p.description || "").toLowerCase().includes(keyword);
+      const inType = (p.type_prestation || "").toLowerCase().includes(keyword);
+      if (!(inDesc || inType)) return false;
+    }
+
+    const price = Number(p.tarif);
+    if (minPrice !== null && price < minPrice) return false;
+    if (maxPrice !== null && price > maxPrice) return false;
+
+    if (dateDepart !== null && new Date(p.date_heure) < new Date(dateDepart)) {
+      return false;
+    }
+    if (dateArrivee !== null && new Date(p.date_heure) > new Date(dateArrivee)) {
+      return false;
+    }
+
+    return true;
+  });
+
   return (
-    <div>
+    <div className="max-w-4xl mx-auto mt-8">
       <h2 className="text-xl font-bold mb-4">Catalogue des prestations</h2>
-      {data && data.length > 0 ? (
-        data.map((p) => (
+
+      <div className="flex flex-wrap items-end gap-4 mb-6">
+        <input
+          type="text"
+          placeholder="Rechercher..."
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          className="p-2 border rounded flex-1 min-w-[150px]"
+        />
+        <input
+          type="number"
+          placeholder="Prix min"
+          value={minPrice ?? ""}
+          onChange={(e) =>
+            setMinPrice(e.target.value === "" ? null : Number(e.target.value))
+          }
+          className="p-2 border rounded w-28"
+        />
+        <input
+          type="number"
+          placeholder="Prix max"
+          value={maxPrice ?? ""}
+          onChange={(e) =>
+            setMaxPrice(e.target.value === "" ? null : Number(e.target.value))
+          }
+          className="p-2 border rounded w-28"
+        />
+        <input
+          type="date"
+          value={dateDepart ?? ""}
+          onChange={(e) =>
+            setDateDepart(e.target.value === "" ? null : e.target.value)
+          }
+          className="p-2 border rounded"
+        />
+        <input
+          type="date"
+          value={dateArrivee ?? ""}
+          onChange={(e) =>
+            setDateArrivee(e.target.value === "" ? null : e.target.value)
+          }
+          className="p-2 border rounded"
+        />
+        <button onClick={handleReset} className="btn-secondary">
+          Réinitialiser les filtres
+        </button>
+      </div>
+
+      {filteredData.length > 0 ? (
+        filteredData.map((p) => (
           <div key={p.id} className="border rounded p-4 mb-4">
             <h3 className="text-lg font-semibold">{p.type_prestation}</h3>
             <p className="my-2">{p.description}</p>


### PR DESCRIPTION
## Summary
- include search/filter bar in `AnnoncesPublic` page
- add the same search/filter UI in `Catalogue` and `CataloguePublic`
- filter data client-side for keywords, price and date

## Testing
- `npm run lint` *(fails: 5 errors, 8 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68738af6c6cc8331a6725b05d917b607