### PR TITLE
Améliore affichage des détails prestation

### DIFF
--- a/packages/frontend/frontoffice/src/pages/PrestationDetail.jsx
+++ b/packages/frontend/frontoffice/src/pages/PrestationDetail.jsx
@@ -78,10 +78,35 @@ export default function PrestationDetail() {
   const isClient = user?.role === "client";
   const isPrestataire = user?.role === "prestataire";
 
+  const formatDate = (d) => {
+    if (!d) return "-";
+    const date = new Date(d);
+    const day = date.toLocaleDateString("fr-FR", {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    });
+    const time = date
+      .toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" })
+      .replace(":", "h");
+    return `${day} à ${time}`;
+  };
+
+  const formatDuration = (mins) => {
+    if (!mins) return "-";
+    const h = Math.floor(mins / 60);
+    const m = mins % 60;
+    if (h && m) return `${h}h${m}`;
+    if (h) return `${h}h`;
+    return `${m} min`;
+  };
+
   return (
-    <div>
+    <div className="max-w-4xl mx-auto mt-8">
       <h2 className="text-xl font-bold mb-4">Détail de la prestation</h2>
       <p className="mb-2">{prestation.description}</p>
+      <p className="mb-2">Date : {formatDate(prestation.date_heure)}</p>
+      <p className="mb-2">Durée estimée : {formatDuration(prestation.duree_estimee)}</p>
       <div className="mb-2">
         Statut : <PrestationStatusBadge status={prestation.statut} />
         {prestation.intervention && prestation.intervention.note !== null && (

--- a/packages/frontend/frontoffice/src/pages/PrestationDetailPublic.jsx
+++ b/packages/frontend/frontoffice/src/pages/PrestationDetailPublic.jsx
@@ -28,14 +28,36 @@ export default function PrestationDetailPublic() {
   if (error) return <p>Erreur lors du chargement.</p>;
   if (!prestation) return <p>Prestation introuvable.</p>;
 
+  const formatDate = (d) => {
+    if (!d) return "-";
+    const date = new Date(d);
+    const day = date.toLocaleDateString("fr-FR", {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    });
+    const time = date
+      .toLocaleTimeString("fr-FR", { hour: "2-digit", minute: "2-digit" })
+      .replace(":", "h");
+    return `${day} à ${time}`;
+  };
+
+  const formatDuration = (mins) => {
+    if (!mins) return "-";
+    const h = Math.floor(mins / 60);
+    const m = mins % 60;
+    if (h && m) return `${h}h${m}`;
+    if (h) return `${h}h`;
+    return `${m} min`;
+  };
+
   return (
-    <div>
+    <div className="max-w-4xl mx-auto mt-8">
       <h2 className="text-xl font-bold mb-4">Détail de la prestation</h2>
       <p className="mb-2">{prestation.description}</p>
+      <p className="mb-2">Date : {formatDate(prestation.date_heure)}</p>
       <p className="mb-2">
-        Date : {new Date(prestation.date_heure).toLocaleString()} - Tarif:
-        {" "}
-        {prestation.tarif} €
+        Durée estimée : {formatDuration(prestation.duree_estimee)} - Tarif: {prestation.tarif} €
       </p>
       <PrestationStatusBadge status={prestation.statut} />
       {prestation.intervention && prestation.intervention.note !== null && (


### PR DESCRIPTION
## Summary
- formate l'affichage de `date_heure` et `duree_estimee`
- centre les pages *PrestationDetail* et *PrestationDetailPublic*
- ajoute fonctions de mise en forme pour date et durée

## Testing
- `npm run lint` in `packages/frontend/frontoffice`
- `npm run lint` in `packages/frontend/backoffice`
- `./vendor/bin/phpunit --display-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68738dcbb0b08331b613ac828e025cd9