### PR TITLE
Create public Devenir prestataire page

### DIFF
--- a/packages/frontend/frontoffice/src/components/Navbar.jsx
+++ b/packages/frontend/frontoffice/src/components/Navbar.jsx
@@ -131,6 +131,14 @@ export default function Navbar() {
               </li>
               <li>
                 <Link
+                  to="/devenir-prestataire"
+                  className="hover:text-lime-300 transition"
+                >
+                  Devenir prestataire
+                </Link>
+              </li>
+              <li>
+                <Link
                   to="/login"
                   className="hover:text-lime-300 transition"
                 >
@@ -293,6 +301,14 @@ export default function Navbar() {
                     className="block hover:text-lime-300"
                   >
                     Prestations
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    to="/devenir-prestataire"
+                    className="block hover:text-lime-300"
+                  >
+                    Devenir prestataire
                   </Link>
                 </li>
                 <li>

--- a/packages/frontend/frontoffice/src/pages/DevenirPrestataire.jsx
+++ b/packages/frontend/frontoffice/src/pages/DevenirPrestataire.jsx
@@ -1,0 +1,37 @@
+import RegisterPrestataire from "./RegisterPrestataire";
+
+export default function DevenirPrestataire() {
+  return (
+    <div className="max-w-3xl mx-auto p-4">
+      <img
+        src={`${import.meta.env.VITE_API_URL}/storage/prestataire-public.png`}
+        alt="Prestataire EcoDeli souriant avec mallette"
+        className="mx-auto mb-6"
+      />
+      <h1 className="text-3xl font-bold text-center mb-4">
+        Devenir prestataire sur EcoDeli
+      </h1>
+      <p className="mb-2">
+        Sur EcoDeli, les prestataires proposent des services utiles au quotidien : aide à domicile, courses, accompagnement, etc.
+      </p>
+      <p className="mb-2">Une fois votre profil validé, vous pourrez :</p>
+      <ul className="list-disc ml-6 space-y-1 mb-4">
+        <li>Publier vos prestations dans votre domaine</li>
+        <li>Gérer vos plannings et vos disponibilités</li>
+        <li>Intervenir chez des clients proches de vous</li>
+        <li>Consulter et générer vos factures mensuelles</li>
+      </ul>
+      <h2 className="text-xl font-semibold mb-2">🧭 Les étapes :</h2>
+      <ol className="list-decimal ml-6 space-y-1 mb-8">
+        <li>Remplissez le formulaire d’inscription et envoyez vos justificatifs</li>
+        <li>Attendez la validation de votre profil par notre équipe</li>
+        <li>Publiez vos prestations et recevez vos premières demandes</li>
+        <li>Intervenez chez les clients, enregistrez vos prestations</li>
+        <li>Recevez vos paiements automatiquement chaque mois</li>
+      </ol>
+      <div className="max-w-xl mx-auto">
+        <RegisterPrestataire />
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/frontoffice/src/routes/Router.jsx
+++ b/packages/frontend/frontoffice/src/routes/Router.jsx
@@ -6,6 +6,7 @@ import Register from "../pages/Register";
 import RegisterCommercant from "../pages/RegisterCommercant";
 import RegisterLivreur from "../pages/RegisterLivreur";
 import RegisterPrestataire from "../pages/RegisterPrestataire";
+import DevenirPrestataire from "../pages/DevenirPrestataire";
 import Profil from "../pages/Profil";
 import EditProfil from "../pages/EditProfil";
 import ChangePassword from "../pages/ChangePassword";
@@ -55,6 +56,7 @@ export default function AppRouter() {
             path="/register-prestataire"
             element={<RegisterPrestataire />}
           />
+          <Route path="/devenir-prestataire" element={<DevenirPrestataire />} />
           <Route
             path="/annonces-public"
             element={


### PR DESCRIPTION
## Summary
- add new public DevenirPrestataire page with info and signup form
- register the page route in Router
- link the page from the desktop and mobile nav menus

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6873ab1a7dac83318aabcf7bf74e2863