### PR TITLE
Add manual invoice generation endpoints

### DIFF
--- a/packages/backend/app/Services/FactureService.php
+++ b/packages/backend/app/Services/FactureService.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Facture;
+use App\Models\Utilisateur;
+use Barryvdh\DomPDF\Facade\Pdf;
+use Illuminate\Support\Facades\Storage;
+
+class FactureService
+{
+    public static function generer(Utilisateur $utilisateur, string $view, array $data, string $chemin, float $montant): Facture
+    {
+        if (!Storage::disk('public')->exists($chemin)) {
+            $pdf = Pdf::loadView($view, $data);
+            Storage::disk('public')->put($chemin, $pdf->output());
+        }
+
+        return Facture::firstOrCreate(
+            [
+                'utilisateur_id' => $utilisateur->id,
+                'chemin_pdf' => $chemin,
+            ],
+            [
+                'montant_total' => $montant,
+                'date_emission' => now(),
+            ]
+        );
+    }
+}

--- a/packages/backend/resources/views/factures/annonce.blade.php
+++ b/packages/backend/resources/views/factures/annonce.blade.php
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Facture {{ $factureNumber }}</title>
+    <style>
+        body { font-family: sans-serif; font-size: 14px; }
+        table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+        th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+        th { background-color: #f2f2f2; }
+    </style>
+</head>
+<body>
+    <h1>Facture n° {{ $factureNumber }}</h1>
+    <p>Date : {{ $date }}</p>
+    <p>{{ ucfirst($role) }} : {{ $utilisateur->prenom }} {{ $utilisateur->nom }} (ID #{{ $utilisateur->id }})</p>
+    <h3>Détail de l'annonce</h3>
+    <table>
+        <tr><th>Titre</th><td>{{ $annonce->titre }}</td></tr>
+        <tr><th>Description</th><td>{{ $annonce->description }}</td></tr>
+        <tr><th>Montant</th><td>{{ number_format($montant, 2) }} €</td></tr>
+    </table>
+</body>
+</html>

--- a/packages/backend/resources/views/factures/livreur.blade.php
+++ b/packages/backend/resources/views/factures/livreur.blade.php
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Facture Livreur {{ $factureNumber }}</title>
+    <style>
+        body { font-family: sans-serif; font-size: 14px; }
+        table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+        th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+        th { background-color: #f2f2f2; }
+    </style>
+</head>
+<body>
+    <h1>Facture n° {{ $factureNumber }}</h1>
+    <p>Date : {{ $date }}</p>
+    <p>Livreur : {{ $livreur->prenom }} {{ $livreur->nom }} (ID #{{ $livreur->id }})</p>
+    <h3>Détails de l'étape</h3>
+    <table>
+        <tr><th>Lieu de départ</th><td>{{ $etape->lieu_depart }}</td></tr>
+        <tr><th>Lieu d'arrivée</th><td>{{ $etape->lieu_arrivee }}</td></tr>
+        <tr><th>Montant</th><td>{{ number_format($montant, 2) }} €</td></tr>
+    </table>
+</body>
+</html>

--- a/packages/backend/routes/api.php
+++ b/packages/backend/routes/api.php
@@ -193,6 +193,9 @@ Route::middleware('auth:sanctum')->group(function () {
     // Factures
     Route::get('/factures', [FactureController::class, 'index']);
     Route::get('/factures/{id}', [FactureController::class, 'show']);
+    Route::post('/factures/livreur/etape/{id}', [FactureController::class, 'genererPourLivreur']);
+    Route::post('/factures/commercant/annonce/{id}', [FactureController::class, 'genererPourCommercant']);
+    Route::post('/factures/client/annonce/{id}', [FactureController::class, 'genererPourClient']);
 
     // Évaluations
     Route::get('/evaluations', [EvaluationController::class, 'index']);


### PR DESCRIPTION
## Summary
- add `FactureService` helper to generate invoice PDFs
- implement manual invoice generation for deliverers, merchants and clients
- expose new routes under `/factures/*`
- provide simple Blade templates for PDF rendering

## Testing
- `composer install --no-interaction`
- `php artisan key:generate`
- `php vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6873c58d7dc08331a1c301bb5d2ac183