### PR TITLE
Add manual invoicing page

### DIFF
--- a/packages/frontend/frontoffice/src/components/Navbar.jsx
+++ b/packages/frontend/frontoffice/src/components/Navbar.jsx
@@ -39,6 +39,7 @@ export default function Navbar() {
         { path: "/prestations/catalogue", label: "Catalogue", group: "prestations" },
         { path: "/prestations", label: "Mes prestations", group: "prestations" },
         { path: "/mes-paiements", label: "Mes paiements", group: "profil" },
+        { path: "/factures-manuelles", label: "Factures", group: "profil" },
       ];
     }
 
@@ -57,6 +58,7 @@ export default function Navbar() {
         ...common,
         { path: "/annonces/creer", label: "Créer une annonce", group: "annonces" },
         { path: "/mes-annonces", label: "Mes annonces", group: "annonces" },
+        { path: "/factures-manuelles", label: "Factures", group: "profil" },
       ];
     }
 
@@ -66,6 +68,7 @@ export default function Navbar() {
         { path: "/mes-trajets", label: "Mes trajets", group: "annonces" },
         { path: "/annonces-disponibles", label: "Annonces disponibles", group: "annonces" },
         { path: "/mes-etapes", label: "Mes étapes", group: "annonces" },
+        { path: "/factures-manuelles", label: "Factures", group: "profil" },
       ];
     }
 

--- a/packages/frontend/frontoffice/src/pages/FacturesManuelles.jsx
+++ b/packages/frontend/frontoffice/src/pages/FacturesManuelles.jsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from "react";
+import api from "../services/api";
+import { useAuth } from "../context/AuthContext";
+
+export default function FacturesManuelles() {
+  const { token, user } = useAuth();
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [btnLoadingId, setBtnLoadingId] = useState(null);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!user) return;
+      setLoading(true);
+      setError("");
+      try {
+        if (user.role === "livreur") {
+          const res = await api.get("/mes-etapes", {
+            headers: { Authorization: `Bearer ${token}` },
+          });
+          const terminees = (res.data || []).filter((e) => e.statut === "terminee");
+          setItems(terminees);
+        } else {
+          const res = await api.get("/mes-annonces", {
+            headers: { Authorization: `Bearer ${token}` },
+          });
+          const payees = (res.data || []).filter((a) => a.is_paid === true);
+          setItems(payees);
+        }
+      } catch (err) {
+        console.error("Erreur chargement :", err);
+        setError("Erreur lors du chargement des données.");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [token, user]);
+
+  const handleGenerate = async (id) => {
+    setBtnLoadingId(id);
+    try {
+      let endpoint = "";
+      if (user.role === "livreur") {
+        endpoint = `/factures/livreur/etape/${id}`;
+      } else if (user.role === "client") {
+        endpoint = `/factures/client/annonce/${id}`;
+      } else {
+        endpoint = `/factures/commercant/annonce/${id}`;
+      }
+      const res = await api.post(endpoint, null, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const url = res.data.url;
+      window.open(url, "_blank");
+    } catch (err) {
+      console.error("Erreur generation facture:", err);
+      alert("Impossible de générer la facture");
+    } finally {
+      setBtnLoadingId(null);
+    }
+  };
+
+  if (loading) return <p className="p-4">Chargement...</p>;
+  if (error) return <p className="text-red-600 p-4">{error}</p>;
+
+  return (
+    <div className="max-w-4xl mx-auto mt-10 p-6 bg-white shadow rounded">
+      <h2 className="text-2xl font-bold mb-6">Mes factures</h2>
+      {items.length === 0 ? (
+        <p>Aucun élément facturable disponible.</p>
+      ) : (
+        <ul className="space-y-4">
+          {items.map((item) => (
+            <li
+              key={item.id}
+              className="border p-4 rounded flex justify-between items-center"
+            >
+              <div>
+                <h3 className="font-semibold">
+                  {user.role === "livreur"
+                    ? `${item.lieu_depart} → ${item.lieu_arrivee}`
+                    : item.titre}
+                </h3>
+                <p className="text-sm text-gray-600">
+                  {new Date(item.created_at).toLocaleDateString()} -
+                  {" "}
+                  {Number(
+                    user.role === "livreur"
+                      ? item.annonce?.prix_propose
+                      : item.prix_propose
+                  ).toLocaleString("fr-FR", {
+                    style: "currency",
+                    currency: "EUR",
+                  })}
+                </p>
+              </div>
+              <button
+                onClick={() => handleGenerate(item.id)}
+                disabled={btnLoadingId === item.id}
+                className="btn-primary disabled:opacity-50"
+              >
+                {btnLoadingId === item.id ? "Génération..." : "Générer la facture"}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/frontend/frontoffice/src/routes/Router.jsx
+++ b/packages/frontend/frontoffice/src/routes/Router.jsx
@@ -23,6 +23,7 @@ import PaiementCancel from "../pages/PaiementCancel";
 import MesAnnonces from "../pages/MesAnnonces";
 import AnnoncesDisponibles from "../pages/AnnoncesDisponibles";
 import Factures from "../pages/Factures";
+import FacturesManuelles from "../pages/FacturesManuelles";
 import ProfilPrestataire from "../pages/ProfilPrestataire";
 import PublierPrestation from "../pages/PublierPrestation";
 import ProfilLivreur from "../pages/ProfilLivreur";
@@ -282,6 +283,17 @@ export default function AppRouter() {
               <PrivateRoute>
                 <RoleRoute role={["prestataire"]}>
                   <Factures />
+                </RoleRoute>
+              </PrivateRoute>
+            }
+          />
+
+          <Route
+            path="/factures-manuelles"
+            element={
+              <PrivateRoute>
+                <RoleRoute role={["livreur", "client", "commercant"]}>
+                  <FacturesManuelles />
                 </RoleRoute>
               </PrivateRoute>
             }


### PR DESCRIPTION
## Summary
- create `FacturesManuelles.jsx` to let deliverers, clients and merchants generate invoices
- expose the page through `/factures-manuelles` route
- show a **Factures** menu entry for relevant roles

## Testing
- `npm run lint` *(fails: several existing lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_6873ccdf1c54833199d413f61f367311