### PR TITLE
Fix logout to revoke tokens

### DIFF
--- a/packages/frontend/backoffice/src/components/Navbar.jsx
+++ b/packages/frontend/backoffice/src/components/Navbar.jsx
@@ -7,8 +7,8 @@ export default function Navbar() {
   const navigate = useNavigate();
   const navRef = useRef(null);
 
-  const handleLogout = () => {
-    logout();
+  const handleLogout = async () => {
+    await logout();
     navigate('/login');
   };
 

--- a/packages/frontend/backoffice/src/context/AuthContext.jsx
+++ b/packages/frontend/backoffice/src/context/AuthContext.jsx
@@ -25,11 +25,17 @@ export function AuthProvider({ children }) {
     localStorage.setItem("user", JSON.stringify(user));
   };
 
-  const logout = () => {
-    setToken(null);
-    setUser(null);
-    localStorage.removeItem("token");
-    localStorage.removeItem("user");
+  const logout = async () => {
+    try {
+      await api.post("/logout");
+    } catch (err) {
+      console.error("Erreur lors de la déconnexion:", err);
+    } finally {
+      setToken(null);
+      setUser(null);
+      localStorage.removeItem("token");
+      localStorage.removeItem("user");
+    }
   };
 
   return (

--- a/packages/frontend/frontoffice/src/components/Navbar.jsx
+++ b/packages/frontend/frontoffice/src/components/Navbar.jsx
@@ -16,8 +16,8 @@ export default function Navbar() {
     }
   }, [user, location, navigate]);
 
-  const handleLogout = () => {
-    logout();
+  const handleLogout = async () => {
+    await logout();
     navigate("/login");
   };
 

--- a/packages/frontend/frontoffice/src/context/AuthContext.jsx
+++ b/packages/frontend/frontoffice/src/context/AuthContext.jsx
@@ -19,11 +19,21 @@ export function AuthProvider({ children }) {
     localStorage.setItem("user", JSON.stringify(user));
   };
 
-  const logout = () => {
-    setToken(null);
-    setUser(null);
-    localStorage.removeItem("token");
-    localStorage.removeItem("user");
+  const logout = async () => {
+    try {
+      await api.post(
+        "/logout",
+        {},
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+    } catch (err) {
+      console.error("Erreur lors de la déconnexion:", err);
+    } finally {
+      setToken(null);
+      setUser(null);
+      localStorage.removeItem("token");
+      localStorage.removeItem("user");
+    }
   };
 
   const completeTutorial = async () => {

--- a/packages/frontend/frontoffice/src/pages/Profil.jsx
+++ b/packages/frontend/frontoffice/src/pages/Profil.jsx
@@ -13,7 +13,7 @@ export default function Profil() {
       await api.delete(`/utilisateurs/${user.id}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
-      logout();
+      await logout();
     } catch {
       setMessage("Erreur lors de la suppression de compte.");
     }


### PR DESCRIPTION
## Summary
- send POST /logout from auth contexts
- await logout before navigating away
- clean up state after backend confirms

## Testing
- `npm run lint` *(fails: ERR_MODULE_NOT_FOUND @eslint/js)*
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6873df6c67908331b225becf1dc84798