### PR TITLE
Switch to Sanctum cookie auth

### DIFF
--- a/packages/frontend/backoffice/src/components/Navbar.jsx
+++ b/packages/frontend/backoffice/src/components/Navbar.jsx
@@ -3,7 +3,7 @@ import { useAuth } from '../context/AuthContext';
 import { useEffect, useRef } from 'react';
 
 export default function Navbar() {
-  const { token, logout } = useAuth();
+  const { user, logout } = useAuth();
   const navigate = useNavigate();
   const navRef = useRef(null);
 
@@ -37,7 +37,7 @@ export default function Navbar() {
       </div>
 
       <div className="flex gap-4 items-center">
-        {!token ? (
+        {!user ? (
           <Link
             to="/login"
             className="admin-btn-primary"

--- a/packages/frontend/backoffice/src/context/AuthContext.jsx
+++ b/packages/frontend/backoffice/src/context/AuthContext.jsx
@@ -5,12 +5,11 @@ const AuthContext = createContext();
 
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(() => JSON.parse(localStorage.getItem("user")));
-  const [token, setToken] = useState(() => localStorage.getItem("token"));
 
   const login = async (identifiant, password) => {
+    await api.get("/sanctum/csrf-cookie");
     const res = await api.post("/login", { identifiant, password });
 
-    const token = res.data.token;
     const user = res.data.user;
 
     // Sécuriser l'accès au backoffice uniquement si l'utilisateur est admin
@@ -18,10 +17,7 @@ export function AuthProvider({ children }) {
       throw new Error("Accès refusé : vous n'êtes pas administrateur");
     }
 
-    setToken(token);
     setUser(user);
-
-    localStorage.setItem("token", token);
     localStorage.setItem("user", JSON.stringify(user));
   };
 
@@ -31,15 +27,13 @@ export function AuthProvider({ children }) {
     } catch (err) {
       console.error("Erreur lors de la déconnexion:", err);
     } finally {
-      setToken(null);
       setUser(null);
-      localStorage.removeItem("token");
       localStorage.removeItem("user");
     }
   };
 
   return (
-    <AuthContext.Provider value={{ user, token, login, logout }}>
+    <AuthContext.Provider value={{ user, login, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/packages/frontend/backoffice/src/routes/PrivateRoute.jsx
+++ b/packages/frontend/backoffice/src/routes/PrivateRoute.jsx
@@ -3,10 +3,10 @@ import { useAuth } from "../context/AuthContext";
 import PropTypes from "prop-types";
 
 export default function PrivateRoute({ children }) {
-  const { token } = useAuth();
+  const { user } = useAuth();
 
-  // Redirection vers /login si pas de token
-  return token ? children : <Navigate to="/login" replace />;
+  // Redirection vers /login si pas connecté
+  return user ? children : <Navigate to="/login" replace />;
 }
 
 PrivateRoute.propTypes = {

--- a/packages/frontend/backoffice/src/services/api.js
+++ b/packages/frontend/backoffice/src/services/api.js
@@ -1,19 +1,13 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL, 
+  baseURL: import.meta.env.VITE_API_URL,
+  withCredentials: true,
   headers: {
     "Content-Type": "application/json",
     Accept: "application/json",
   },
 });
 
-api.interceptors.request.use((config) => {
-  const token = localStorage.getItem("token");
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
-  }
-  return config;
-});
 
 export default api;

--- a/packages/frontend/frontoffice/src/components/ActionButtons.jsx
+++ b/packages/frontend/frontoffice/src/components/ActionButtons.jsx
@@ -5,7 +5,7 @@ import { useAuth } from "../context/AuthContext";
 
 // Boutons d'actions pour le prestataire selon le statut de la prestation
 export default function ActionButtons({ prestationId, statut, onChange }) {
-  const { token } = useAuth();
+  useAuth();
   const [loading, setLoading] = useState(false);
 
   const changerStatut = async (nouveauStatut) => {
@@ -14,7 +14,6 @@ export default function ActionButtons({ prestationId, statut, onChange }) {
       await api.patch(
         `/prestations/${prestationId}/statut`,
         { statut: nouveauStatut },
-        { headers: { Authorization: `Bearer ${token}` } }
       );
       if (onChange) onChange();
     } catch (err) {

--- a/packages/frontend/frontoffice/src/components/EvaluationForm.jsx
+++ b/packages/frontend/frontoffice/src/components/EvaluationForm.jsx
@@ -5,7 +5,7 @@ import { useAuth } from "../context/AuthContext";
 
 // Formulaire d\'évaluation d\'une prestation terminée
 export default function EvaluationForm({ interventionId, onSubmit }) {
-  const { token } = useAuth();
+  useAuth();
   const [note, setNote] = useState(1);
   const [commentaire, setCommentaire] = useState("");
   const [loading, setLoading] = useState(false);
@@ -23,7 +23,6 @@ export default function EvaluationForm({ interventionId, onSubmit }) {
           note,
           commentaire_client: commentaire,
         },
-        { headers: { Authorization: `Bearer ${token}` } }
       );
       setCommentaire("");
       setNote(1);

--- a/packages/frontend/frontoffice/src/context/AuthContext.jsx
+++ b/packages/frontend/frontoffice/src/context/AuthContext.jsx
@@ -5,44 +5,31 @@ const AuthContext = createContext();
 
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(() => JSON.parse(localStorage.getItem("user")));
-  const [token, setToken] = useState(() => localStorage.getItem("token"));
 
   const login = async (email, password) => {
+    await api.get("/sanctum/csrf-cookie");
     const res = await api.post("/login", { email, password });
-    const token = res.data.token;
     const user = res.data.user;
 
-    setToken(token);
     setUser(user);
 
-    localStorage.setItem("token", token);
     localStorage.setItem("user", JSON.stringify(user));
   };
 
   const logout = async () => {
     try {
-      await api.post(
-        "/logout",
-        {},
-        { headers: { Authorization: `Bearer ${token}` } }
-      );
+      await api.post("/logout");
     } catch (err) {
       console.error("Erreur lors de la déconnexion:", err);
     } finally {
-      setToken(null);
       setUser(null);
-      localStorage.removeItem("token");
       localStorage.removeItem("user");
     }
   };
 
   const completeTutorial = async () => {
     try {
-      await api.patch(
-        "/user/tutorial",
-        {},
-        { headers: { Authorization: `Bearer ${token}` } }
-      );
+      await api.patch("/user/tutorial");
       updateUser({ tutorial_done: true });
     } catch (err) {
       console.error("Erreur validation tutoriel:", err);
@@ -57,7 +44,7 @@ export function AuthProvider({ children }) {
   };
 
   return (
-    <AuthContext.Provider value={{ user, token, login, logout, updateUser, completeTutorial }}>
+    <AuthContext.Provider value={{ user, login, logout, updateUser, completeTutorial }}>
       {children}
     </AuthContext.Provider>
   );

--- a/packages/frontend/frontoffice/src/pages/AnnonceDetail.jsx
+++ b/packages/frontend/frontoffice/src/pages/AnnonceDetail.jsx
@@ -6,7 +6,7 @@ import api from "../services/api";
 export default function AnnonceDetail() {
   const { id } = useParams();
   const navigate = useNavigate();
-  const { token, user } = useAuth();
+  const { user } = useAuth();
   const [annonce, setAnnonce] = useState(null);
   const [loading, setLoading] = useState(true);
 
@@ -14,7 +14,6 @@ export default function AnnonceDetail() {
     const fetchAnnonce = async () => {
       try {
         const res = await api.get(`/annonces/${id}`, {
-          headers: { Authorization: `Bearer ${token}` },
         });
         setAnnonce(res.data);
       } catch (err) {
@@ -25,7 +24,7 @@ export default function AnnonceDetail() {
     };
 
     fetchAnnonce();
-  }, [id, token]);
+  }, [id]);
 
 
   if (loading) return <p className="mt-10 text-center">Chargement...</p>;

--- a/packages/frontend/frontoffice/src/pages/Annonces.jsx
+++ b/packages/frontend/frontoffice/src/pages/Annonces.jsx
@@ -5,7 +5,7 @@ import { useNavigate } from "react-router-dom";
 
 export default function Annonces() {
   const [annonces, setAnnonces] = useState([]);
-  const { user, token } = useAuth();
+  const { user } = useAuth();
   const navigate = useNavigate();
 
   const [searchText, setSearchText] = useState("");
@@ -24,7 +24,6 @@ export default function Annonces() {
     const fetchAnnonces = async () => {
       try {
         const res = await api.get("/annonces", {
-          headers: { Authorization: `Bearer ${token}` },
         });
 
         // Filtrer uniquement les annonces de type "produit_livre" qui ne sont
@@ -41,7 +40,7 @@ export default function Annonces() {
     };
 
     fetchAnnonces();
-  }, [token]);
+  }, []);
 
   const handleReset = () => {
     setSearchText("");

--- a/packages/frontend/frontoffice/src/pages/AnnoncesDisponibles.jsx
+++ b/packages/frontend/frontoffice/src/pages/AnnoncesDisponibles.jsx
@@ -4,7 +4,7 @@ import { useAuth } from "../context/AuthContext";
 import { useNavigate } from "react-router-dom";
 
 export default function AnnoncesDisponibles() {
-  const { token, user } = useAuth();
+  const { user } = useAuth();
   const [annoncesDisponibles, setAnnoncesDisponibles] = useState([]);
   const [livreur, setLivreur] = useState(null);
   const [error, setError] = useState("");
@@ -18,7 +18,7 @@ export default function AnnoncesDisponibles() {
   useEffect(() => {
     if (!user) return;
     api
-      .get(`/livreurs/${user.id}`, { headers: { Authorization: `Bearer ${token}` } })
+      .get(`/livreurs/${user.id}`)
       .then((res) => {
         setLivreur(res.data);
         if (res.data.statut === "valide") {
@@ -27,13 +27,11 @@ export default function AnnoncesDisponibles() {
       })
       .catch(() => setLivreur(null));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [user, token]);
+  }, [user]);
 
   const fetchAnnonces = async () => {
     try {
-      const res = await api.get("/annonces-disponibles", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const res = await api.get("/annonces-disponibles");
       setAnnoncesDisponibles(res.data.annonces_disponibles);
     } catch (err) {
       console.error("Erreur API :", err);
@@ -45,9 +43,7 @@ export default function AnnoncesDisponibles() {
     if (!window.confirm("Accepter cette annonce ?")) return;
 
     try {
-      await api.post(`/annonces/${annonceId}/accepter`, null, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      await api.post(`/annonces/${annonceId}/accepter`);
       alert("Étape de livraison créée. Vous pouvez la suivre dans 'Mes étapes'.");
       navigate("/mes-etapes");
     } catch (err) {

--- a/packages/frontend/frontoffice/src/pages/Catalogue.jsx
+++ b/packages/frontend/frontoffice/src/pages/Catalogue.jsx
@@ -8,7 +8,8 @@ export default function Catalogue() {
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const { token } = useAuth();
+  useAuth();
+  const {} = useAuth();
   const [searchText, setSearchText] = useState("");
   const [minPrice, setMinPrice] = useState(null);
   const [maxPrice, setMaxPrice] = useState(null);
@@ -19,7 +20,6 @@ export default function Catalogue() {
     const fetchData = async () => {
       try {
         const res = await api.get("/prestations/catalogue", {
-          headers: { Authorization: `Bearer ${token}` },
         });
         setData(res.data);
       } catch (err) {
@@ -30,7 +30,7 @@ export default function Catalogue() {
     };
     fetchData();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [token]);
+  }, []);
 
   if (loading) return <p>Chargement...</p>;
   if (error) return <p>Erreur lors du chargement.</p>;

--- a/packages/frontend/frontoffice/src/pages/ChangePassword.jsx
+++ b/packages/frontend/frontoffice/src/pages/ChangePassword.jsx
@@ -4,7 +4,7 @@ import api from "../services/api";
 import { useNavigate, Link } from "react-router-dom";
 
 export default function ChangePassword() {
-  const { user, token } = useAuth();
+  const { user } = useAuth();
   const navigate = useNavigate();
   const [currentPassword, setCurrentPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
@@ -22,8 +22,6 @@ export default function ChangePassword() {
         current_password: currentPassword,
         password: newPassword,
         password_confirmation: confirmPassword,
-      }, {
-        headers: { Authorization: `Bearer ${token}` }
       });
 
       setMessage("✅ Mot de passe mis à jour avec succès.");

--- a/packages/frontend/frontoffice/src/pages/CreerAnnonce.jsx
+++ b/packages/frontend/frontoffice/src/pages/CreerAnnonce.jsx
@@ -4,7 +4,7 @@ import { useAuth } from "../context/AuthContext";
 import api from "../services/api";
 
 export default function CreerAnnonce() {
-  const { user, token } = useAuth();
+  const { user } = useAuth();
   const navigate = useNavigate();
   // Déterminer le type selon le rôle
   let typeAnnonce = null;
@@ -29,7 +29,6 @@ export default function CreerAnnonce() {
     const fetchEntrepots = async () => {
       try {
         const res = await api.get("/entrepots", {
-          headers: { Authorization: `Bearer ${token}` },
         });
         setEntrepots(res.data);
       } catch (err) {
@@ -37,7 +36,7 @@ export default function CreerAnnonce() {
       }
     };
     fetchEntrepots();
-  }, [token]);
+  }, []);
 
 
   if (!typeAnnonce) {
@@ -87,7 +86,6 @@ export default function CreerAnnonce() {
       if (photoFile) data.append("photo", photoFile);
       await api.post("/annonces", data, {
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "multipart/form-data",
         },
       });

--- a/packages/frontend/frontoffice/src/pages/Disponibilites.jsx
+++ b/packages/frontend/frontoffice/src/pages/Disponibilites.jsx
@@ -5,7 +5,7 @@ import api from "../services/api";
 import PlanningForm from "../components/PlanningForm";
 
 export default function Disponibilites() {
-  const { token, user } = useAuth();
+  const { user } = useAuth();
 
   const [slots, setSlots] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -19,9 +19,7 @@ export default function Disponibilites() {
     setLoading(true);
     setError("");
     try {
-      const res = await api.get("/plannings", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const res = await api.get("/plannings");
       setSlots(res.data);
     } catch (err) {
       setError("Erreur lors du chargement des créneaux.");
@@ -33,18 +31,16 @@ export default function Disponibilites() {
   useEffect(() => {
     if (!user) return;
     api
-      .get(`/prestataires/${user.id}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
+      .get(`/prestataires/${user.id}`)
       .then((res) => setPrestataire(res.data))
       .catch(() => setPrestataire(null))
       .finally(() => setLoadingPrestataire(false));
-  }, [user, token]);
+  }, [user]);
 
   useEffect(() => {
     fetchSlots();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [token]);
+  }, []);
 
   const handleAddSlot = async ({ date, heure_debut, heure_fin }) => {
     // vérifie localement les chevauchements de créneau
@@ -62,8 +58,7 @@ export default function Disponibilites() {
     try {
       await api.post(
         "/plannings",
-        { date_disponible: date, heure_debut, heure_fin },
-        { headers: { Authorization: `Bearer ${token}` } }
+        { date_disponible: date, heure_debut, heure_fin }
       );
       setMessage("Créneau ajouté avec succès.");
       fetchSlots();
@@ -77,9 +72,7 @@ export default function Disponibilites() {
   const handleDelete = async (id) => {
     if (!window.confirm("Supprimer ce créneau ?")) return;
     try {
-      await api.delete(`/plannings/${id}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      await api.delete(`/plannings/${id}`);
       setSlots((prev) => prev.filter((s) => s.id !== id));
     } catch (err) {
       alert("Erreur lors de la suppression.");

--- a/packages/frontend/frontoffice/src/pages/EditMesAnnonce.jsx
+++ b/packages/frontend/frontoffice/src/pages/EditMesAnnonce.jsx
@@ -6,7 +6,7 @@ import { useAuth } from "../context/AuthContext";
 export default function EditMesAnnonce() {
   const { id } = useParams();
   const navigate = useNavigate();
-  const { user, token } = useAuth();
+  const { user } = useAuth();
 
   const [annonce, setAnnonce] = useState(null);
   const [form, setForm] = useState({ titre: "", description: "", prix_propose: "", lieu_depart: "", lieu_arrivee: "", photo: "" });
@@ -19,7 +19,6 @@ export default function EditMesAnnonce() {
   const fetchAnnonce = async () => {
     try {
       const res = await api.get(`/annonces/${id}`, {
-        headers: { Authorization: `Bearer ${token}` },
       });
       const data = res.data;
       setAnnonce(data);
@@ -47,7 +46,6 @@ export default function EditMesAnnonce() {
     e.preventDefault();
     try {
       await api.patch(`/annonces/${id}`, form, {
-        headers: { Authorization: `Bearer ${token}` },
       });
       alert("Annonce mise à jour");
       fetchAnnonce();
@@ -61,7 +59,6 @@ export default function EditMesAnnonce() {
     if (!window.confirm("Confirmer la suppression de cette annonce ?")) return;
     try {
       await api.delete(`/annonces/${id}`, {
-        headers: { Authorization: `Bearer ${token}` },
       });
       alert("Annonce supprimée.");
       navigate("/mes-annonces");

--- a/packages/frontend/frontoffice/src/pages/EditProfil.jsx
+++ b/packages/frontend/frontoffice/src/pages/EditProfil.jsx
@@ -4,12 +4,12 @@ import api from "../services/api";
 import { Link } from "react-router-dom";
 
 export default function EditProfil() {
-  const { user, token, updateUser } = useAuth();
+  const { user, updateUser } = useAuth();
   const [formData, setFormData] = useState({});
   const [message, setMessage] = useState("");
 
   useEffect(() => {
-    if (!user || !token) return;
+    if (!user) return;
     setFormData({
       nom: user.nom, prenom: user.prenom, email: user.email,
       pays: user.pays, telephone: user.telephone, adresse_postale: user.adresse_postale,
@@ -20,9 +20,7 @@ export default function EditProfil() {
 
     const loadRoleData = async () => {
       try {
-        const res = await api.get(`/${user.role}s/${user.id}`, {
-          headers: { Authorization: `Bearer ${token}` }
-        });
+        const res = await api.get(`/${user.role}s/${user.id}`);
         setFormData((prev) => ({ ...prev, ...res.data }));
       } catch {
         setMessage("Erreur lors du chargement des données spécifiques.");
@@ -30,7 +28,7 @@ export default function EditProfil() {
     };
 
     loadRoleData();
-  }, [user, token]);
+  }, [user]);
 
   const handleChange = (e) => setFormData({ ...formData, [e.target.name]: e.target.value });
 
@@ -49,9 +47,7 @@ export default function EditProfil() {
 
     try {
       // PATCH utilisateur
-      await api.patch(`/utilisateurs/${user.id}`, utilisateurData, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      await api.patch(`/utilisateurs/${user.id}`, utilisateurData);
 
       // 🔄 MAJ user dans localStorage
       updateUser(utilisateurData);
@@ -70,9 +66,7 @@ export default function EditProfil() {
           roleData.description = formData.description;
         }
 
-        await api.patch(`/${user.role}s/${user.id}`, roleData, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
+        await api.patch(`/${user.role}s/${user.id}`, roleData);
       }
 
       setMessage("✅ Profil mis à jour avec succès.");

--- a/packages/frontend/frontoffice/src/pages/Factures.jsx
+++ b/packages/frontend/frontoffice/src/pages/Factures.jsx
@@ -5,7 +5,7 @@ import api from "../services/api";
 import FactureCard from "../components/FactureCard";
 
 export default function Factures() {
-  const { token } = useAuth();
+  useAuth();
   const [factures, setFactures] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -14,7 +14,6 @@ export default function Factures() {
     const fetchFactures = async () => {
       try {
         const res = await api.get("/factures-prestataire", {
-          headers: { Authorization: `Bearer ${token}` },
         });
         setFactures(res.data);
       } catch (err) {
@@ -25,7 +24,7 @@ export default function Factures() {
       }
     };
     fetchFactures();
-  }, [token]);
+  }, []);
 
   if (loading) return <p>Chargement...</p>;
   if (error) return <p className="text-red-600">{error}</p>;

--- a/packages/frontend/frontoffice/src/pages/FacturesManuelles.jsx
+++ b/packages/frontend/frontoffice/src/pages/FacturesManuelles.jsx
@@ -3,7 +3,7 @@ import api from "../services/api";
 import { useAuth } from "../context/AuthContext";
 
 export default function FacturesManuelles() {
-  const { token, user } = useAuth();
+  const { user } = useAuth();
   const [items, setItems] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -16,15 +16,11 @@ export default function FacturesManuelles() {
       setError("");
       try {
         if (user.role === "livreur") {
-          const res = await api.get("/mes-etapes", {
-            headers: { Authorization: `Bearer ${token}` },
-          });
+          const res = await api.get("/mes-etapes");
           const terminees = (res.data || []).filter((e) => e.statut === "terminee");
           setItems(terminees);
         } else {
-          const res = await api.get("/mes-annonces", {
-            headers: { Authorization: `Bearer ${token}` },
-          });
+          const res = await api.get("/mes-annonces");
           const payees = (res.data || []).filter((a) => a.is_paid === true);
           setItems(payees);
         }
@@ -36,7 +32,7 @@ export default function FacturesManuelles() {
       }
     };
     load();
-  }, [token, user]);
+  }, [user]);
 
   const handleGenerate = async (id) => {
     setBtnLoadingId(id);
@@ -49,9 +45,7 @@ export default function FacturesManuelles() {
       } else {
         endpoint = `/factures/commercant/annonce/${id}`;
       }
-      const res = await api.post(endpoint, null, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const res = await api.post(endpoint);
       const url = res.data.url;
       window.open(url, "_blank");
     } catch (err) {

--- a/packages/frontend/frontoffice/src/pages/MesAnnonces.jsx
+++ b/packages/frontend/frontoffice/src/pages/MesAnnonces.jsx
@@ -5,7 +5,7 @@ import { useAuth } from "../context/AuthContext";
 import { Link } from "react-router-dom";
 
 export default function MesAnnonces() {
-  const { token } = useAuth();
+  useAuth();
   const [annonces, setAnnonces] = useState([]);
   const [payLoadingId, setPayLoadingId] = useState(null);
 
@@ -13,7 +13,6 @@ export default function MesAnnonces() {
     const fetchAnnonces = async () => {
       try {
         const res = await api.get("/mes-annonces", {
-          headers: { Authorization: `Bearer ${token}` },
         });
         setAnnonces(res.data);
       } catch (err) {
@@ -22,13 +21,12 @@ export default function MesAnnonces() {
     };
 
     fetchAnnonces();
-  }, [token]);
+  }, []);
 
   const handleDelete = async (id) => {
     if (!window.confirm("Confirmez-vous l'annulation de cette annonce ?")) return;
     try {
       await api.delete(`/annonces/${id}`, {
-        headers: { Authorization: `Bearer ${token}` },
       });
       setAnnonces((prev) => prev.filter((a) => a.id !== id));
     } catch (err) {
@@ -44,7 +42,7 @@ export default function MesAnnonces() {
       localStorage.setItem("payerAnnonceId", annonce.id);
       const { checkout_url } = await createCheckoutSession(
         { annonce_id: annonce.id, type: annonce.type },
-        token,
+        undefined,
         "payer"
       );
       window.location.href = checkout_url;

--- a/packages/frontend/frontoffice/src/pages/MesEtapes.jsx
+++ b/packages/frontend/frontoffice/src/pages/MesEtapes.jsx
@@ -4,7 +4,7 @@ import { useAuth } from "../context/AuthContext";
 import { Link, useNavigate } from "react-router-dom";
 
 export default function MesEtapes() {
-  const { token, user } = useAuth();
+  const { user } = useAuth();
   const livreur = user?.livreur;
   const navigate = useNavigate();
   const [etapes, setEtapes] = useState([]);
@@ -12,9 +12,7 @@ export default function MesEtapes() {
 
   const fetchEtapes = async () => {
     try {
-      const res = await api.get("/mes-etapes", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const res = await api.get("/mes-etapes");
 
       const toutes = res.data;
       const livreurEtapes = toutes.filter(
@@ -30,7 +28,7 @@ export default function MesEtapes() {
 
   useEffect(() => {
     fetchEtapes();
-  }, [token]);
+  }, []);
 
   if (livreur && livreur.statut !== "valide") {
     return (

--- a/packages/frontend/frontoffice/src/pages/MesTrajets.jsx
+++ b/packages/frontend/frontoffice/src/pages/MesTrajets.jsx
@@ -3,7 +3,7 @@ import api from "../services/api";
 import { useAuth } from "../context/AuthContext";
 
 export default function MesTrajets() {
-  const { token, user } = useAuth();
+  const { user } = useAuth();
   const [trajets, setTrajets] = useState([]);
   const [livreur, setLivreur] = useState(null);
   const [entrepots, setEntrepots] = useState([]);
@@ -18,7 +18,7 @@ export default function MesTrajets() {
     fetchEntrepots();
     if (user) {
       api
-        .get(`/livreurs/${user.id}`, { headers: { Authorization: `Bearer ${token}` } })
+        .get(`/livreurs/${user.id}`)
         .then((res) => {
           setLivreur(res.data);
           if (res.data.statut === "valide") {
@@ -31,9 +31,7 @@ export default function MesTrajets() {
 
   const fetchEntrepots = async () => {
     try {
-      const res = await api.get("/entrepots", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const res = await api.get("/entrepots");
       setEntrepots(res.data);
     } catch (err) {
       console.error("Erreur chargement entrepôts:", err);
@@ -42,9 +40,7 @@ export default function MesTrajets() {
 
   const fetchTrajets = async () => {
     try {
-      const res = await api.get("/mes-trajets", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const res = await api.get("/mes-trajets");
       setTrajets(res.data);
     } catch (err) {
       console.error("Erreur trajets:", err);
@@ -64,9 +60,7 @@ export default function MesTrajets() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      await api.post("/mes-trajets", form, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      await api.post("/mes-trajets", form);
       setForm({
         entrepot_depart_id: "",
         entrepot_arrivee_id: "",
@@ -83,9 +77,7 @@ export default function MesTrajets() {
   const handleDelete = async (id) => {
     if (!window.confirm("Supprimer ce trajet ?")) return;
     try {
-      await api.delete(`/mes-trajets/${id}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      await api.delete(`/mes-trajets/${id}`);
       fetchTrajets();
     } catch (err) {
       console.error("Erreur suppression:", err);

--- a/packages/frontend/frontoffice/src/pages/Notifications.jsx
+++ b/packages/frontend/frontoffice/src/pages/Notifications.jsx
@@ -3,15 +3,13 @@ import api from "../services/api";
 import { useAuth } from "../context/AuthContext";
 
 export default function Notifications() {
-  const { token, user } = useAuth();
+  const { user } = useAuth();
   const [notifications, setNotifications] = useState([]);
   const [verificationSent, setVerificationSent] = useState(false);
 
   const fetchNotifications = async () => {
     try {
-      const res = await api.get("/notifications", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const res = await api.get("/notifications");
       setNotifications(res.data);
     } catch (err) {
       console.error("Erreur lors du chargement des notifications :", err);
@@ -20,9 +18,7 @@ export default function Notifications() {
 
   const handleResendVerification = async () => {
     try {
-      await api.post("/email/verification-notification", null, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      await api.post("/email/verification-notification");
       setVerificationSent(true);
     } catch (err) {
       console.error("Erreur lors de l'envoi de l'email :", err);
@@ -32,7 +28,7 @@ export default function Notifications() {
 
   useEffect(() => {
     fetchNotifications();
-  }, [token]);
+  }, []);
 
   return (
     <div className="max-w-3xl mx-auto mt-10 px-4">

--- a/packages/frontend/frontoffice/src/pages/PaiementSuccess.jsx
+++ b/packages/frontend/frontoffice/src/pages/PaiementSuccess.jsx
@@ -6,7 +6,7 @@ import { useAuth } from "../context/AuthContext";
 export default function PaiementSuccess() {
   const [message, setMessage] = useState("");
   const [searchParams] = useSearchParams();
-  const { token } = useAuth();
+  const {} = useAuth();
   const navigate = useNavigate();
   const finalized = useRef(false);
 
@@ -42,12 +42,11 @@ export default function PaiementSuccess() {
             await api.post(
               `/annonces/${annonceId}/reserver`,
               { entrepot_arrivee_id: Number(entrepotId) },
-              { headers: { Authorization: `Bearer ${token}` } }
+              
             );
 
             await api.get(`/annonces/${annonceId}/paiement-callback`, {
               params: { session_id: sessionId },
-              headers: { Authorization: `Bearer ${token}` },
             });
 
             localStorage.removeItem("reservationEntrepot");
@@ -65,7 +64,6 @@ export default function PaiementSuccess() {
             try {
               await api.get(`/annonces/${annonceId}/paiement-callback`, {
                 params: { session_id: sessionId },
-                headers: { Authorization: `Bearer ${token}` },
               });
             } catch (err) {
               console.error("Erreur callback paiement :", err);
@@ -77,7 +75,6 @@ export default function PaiementSuccess() {
             try {
               await api.get(`/prestations/${prestationId}/paiement-callback`, {
                 params: { session_id: sessionId },
-                headers: { Authorization: `Bearer ${token}` },
               });
             } catch (err) {
               console.error("Erreur callback paiement prestation:", err);
@@ -103,7 +100,6 @@ export default function PaiementSuccess() {
           }
           await api.post("/annonces", formData, {
             headers: {
-              Authorization: `Bearer ${token}`,
               "Content-Type": "multipart/form-data",
             },
           });
@@ -129,7 +125,7 @@ export default function PaiementSuccess() {
     };
 
     finalize();
-  }, [searchParams, token, navigate]);
+  }, [searchParams, navigate]);
 
   return (
     <div className="max-w-xl mx-auto mt-10 p-6 bg-white shadow rounded">

--- a/packages/frontend/frontoffice/src/pages/PrestationDetail.jsx
+++ b/packages/frontend/frontoffice/src/pages/PrestationDetail.jsx
@@ -10,7 +10,7 @@ import ActionButtons from "../components/ActionButtons";
 export default function PrestationDetail() {
   const { id } = useParams();
   const navigate = useNavigate();
-  const { token, user } = useAuth();
+  const { user } = useAuth();
   const [prestation, setPrestation] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
@@ -19,10 +19,7 @@ export default function PrestationDetail() {
     setLoading(true);
     setError("");
     try {
-      const storedToken = localStorage.getItem("token");
-      const res = await api.get(`/prestations/${id}`, {
-        headers: { Authorization: `Bearer ${storedToken}` },
-      });
+      const res = await api.get(`/prestations/${id}`);
       setPrestation(res.data);
       console.log(res.data); // suivi de la prestation reçue
     } catch (err) {
@@ -48,7 +45,6 @@ export default function PrestationDetail() {
       localStorage.setItem("paymentContext", "prestation_reserver");
       localStorage.setItem("prestationId", id);
       const res = await api.post(`/prestations/${id}/payer`, null, {
-        headers: { Authorization: `Bearer ${token}` },
       });
       window.location.href = res.data.checkout_url;
     } catch (err) {
@@ -62,7 +58,7 @@ export default function PrestationDetail() {
       await api.post(
         "/interventions",
         { prestation_id: id, statut_final: "effectuée" },
-        { headers: { Authorization: `Bearer ${token}` } }
+        
       );
       fetchPrestation();
     } catch (err) {

--- a/packages/frontend/frontoffice/src/pages/Prestations.jsx
+++ b/packages/frontend/frontoffice/src/pages/Prestations.jsx
@@ -5,7 +5,7 @@ import api from "../services/api";
 import PrestationCard from "../components/PrestationCard";
 
 export default function Prestations() {
-  const { token, user, updateUser } = useAuth();
+  const { user, updateUser } = useAuth();
   const [data, setData] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -17,7 +17,6 @@ export default function Prestations() {
     const fetchData = async () => {
       try {
         const res = await api.get("/prestations", {
-          headers: { Authorization: `Bearer ${token}` },
         });
         setData(res.data);
       } catch (err) {
@@ -27,7 +26,7 @@ export default function Prestations() {
       }
     };
     fetchData();
-  }, [token]);
+  }, []);
 
   // Récupération des infos détaillées de l'utilisateur
   useEffect(() => {
@@ -43,7 +42,6 @@ export default function Prestations() {
         if (!endpoint) return;
 
         const res = await api.get(endpoint, {
-          headers: { Authorization: `Bearer ${token}` },
         });
 
         if (user.role === "client") {
@@ -59,8 +57,8 @@ export default function Prestations() {
       }
     };
 
-    if (token && user) fetchUser();
-  }, [token, user, updateUser]);
+    if (user) fetchUser();
+  }, [user, updateUser]);
 
   if (loading || loadingUser) return <p>Chargement...</p>;
   if (error) return <p>Erreur lors du chargement.</p>;

--- a/packages/frontend/frontoffice/src/pages/Profil.jsx
+++ b/packages/frontend/frontoffice/src/pages/Profil.jsx
@@ -4,15 +4,13 @@ import api from "../services/api";
 import { Link } from "react-router-dom";
 
 export default function Profil() {
-  const { user, token, logout } = useAuth();
+  const { user, logout } = useAuth();
   const [message, setMessage] = useState("");
 
   const handleDelete = async () => {
     if (!window.confirm("Confirmez-vous la suppression de votre compte ?")) return;
     try {
-      await api.delete(`/utilisateurs/${user.id}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      await api.delete(`/utilisateurs/${user.id}`);
       await logout();
     } catch {
       setMessage("Erreur lors de la suppression de compte.");

--- a/packages/frontend/frontoffice/src/pages/ProfilLivreur.jsx
+++ b/packages/frontend/frontoffice/src/pages/ProfilLivreur.jsx
@@ -5,7 +5,7 @@ import api from "../services/api";
 const STORAGE_BASE_URL = api.defaults.baseURL.replace("/api", "");
 
 export default function ProfilLivreur() {
-  const { user, token } = useAuth();
+  const { user } = useAuth();
   const [livreur, setLivreur] = useState(null);
   const [files, setFiles] = useState({ identite: null, permis: null });
   const [uploading, setUploading] = useState(false);
@@ -14,10 +14,10 @@ export default function ProfilLivreur() {
   useEffect(() => {
     if (!user) return;
     api
-      .get(`/livreurs/${user.id}`, { headers: { Authorization: `Bearer ${token}` } })
+      .get(`/livreurs/${user.id}`)
       .then((res) => setLivreur(res.data))
       .catch(() => setError("Erreur de chargement"));
-  }, [user, token]);
+  }, [user]);
 
   const statutLabel =
     livreur?.statut === "valide"
@@ -35,7 +35,6 @@ export default function ProfilLivreur() {
     try {
       const res = await api.post("/livreurs/justificatifs", data, {
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "multipart/form-data",
         },
       });
@@ -54,9 +53,7 @@ export default function ProfilLivreur() {
   const handleDelete = async (type) => {
     if (!window.confirm("Supprimer ce document ?")) return;
     try {
-      await api.delete(`/livreurs/justificatifs/${type}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      await api.delete(`/livreurs/justificatifs/${type}`);
       setLivreur((prev) => ({
         ...prev,
         [`${type}_document`]: null,

--- a/packages/frontend/frontoffice/src/pages/ProfilPrestataire.jsx
+++ b/packages/frontend/frontoffice/src/pages/ProfilPrestataire.jsx
@@ -5,7 +5,7 @@ import api from "../services/api";
 const STORAGE_BASE_URL = api.defaults.baseURL.replace("/api", "");
 
 export default function ProfilPrestataire() {
-  const { user, token } = useAuth();
+  const { user } = useAuth();
   const [prestataire, setPrestataire] = useState(null);
   const [evaluations, setEvaluations] = useState([]);
   const [justificatifs, setJustificatifs] = useState([]);
@@ -17,15 +17,15 @@ export default function ProfilPrestataire() {
   useEffect(() => {
     if (!user) return;
     api
-      .get(`/prestataires/${user.id}`, { headers: { Authorization: `Bearer ${token}` } })
+      .get(`/prestataires/${user.id}`)
       .then((res) => setPrestataire(res.data))
       .catch(() => setError("Erreur de chargement"));
-  }, [user, token]);
+  }, [user]);
 
   useEffect(() => {
-    if (!token || !user) return;
+    if (!user) return;
     api
-      .get("/prestations", { headers: { Authorization: `Bearer ${token}` } })
+      .get("/prestations")
       .then((res) => {
         const evals = res.data.filter(
           (p) =>
@@ -37,17 +37,14 @@ export default function ProfilPrestataire() {
         setEvaluations(evals);
       })
       .catch(() => {});
-  }, [token, user, prestataire]);
+  }, [user, prestataire]);
 
   useEffect(() => {
-    if (!token) return;
     api
-      .get("/prestataires/justificatifs", {
-        headers: { Authorization: `Bearer ${token}` },
-      })
+      .get("/prestataires/justificatifs")
       .then((res) => setJustificatifs(res.data))
       .catch(() => setUploadError("Erreur chargement des justificatifs"));
-  }, [token]);
+  }, []);
 
   const handleUpload = async () => {
     if (!newFile) return;
@@ -57,18 +54,15 @@ export default function ProfilPrestataire() {
     try {
       await api.post("/prestataires/justificatifs", data, {
         headers: {
-          Authorization: `Bearer ${token}`,
           "Content-Type": "multipart/form-data",
         },
       });
 
       const list = await api.get("/prestataires/justificatifs", {
-        headers: { Authorization: `Bearer ${token}` },
       });
       setJustificatifs(list.data);
 
       const profil = await api.get(`/prestataires/${user.id}`, {
-        headers: { Authorization: `Bearer ${token}` },
       });
       setPrestataire(profil.data);
       alert(

--- a/packages/frontend/frontoffice/src/pages/PublierPrestation.jsx
+++ b/packages/frontend/frontoffice/src/pages/PublierPrestation.jsx
@@ -5,7 +5,7 @@ import api from "../services/api";
 import { useNavigate } from "react-router-dom";
 
 export default function PublierPrestation() {
-  const { token, user } = useAuth();
+  const { user } = useAuth();
   const navigate = useNavigate();
 
   const [form, setForm] = useState({
@@ -27,20 +27,16 @@ export default function PublierPrestation() {
   useEffect(() => {
     if (!user) return;
     api
-      .get(`/prestataires/${user.id}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
+      .get(`/prestataires/${user.id}`)
       .then((res) => setPrestataire(res.data))
       .catch(() => setPrestataire(null))
       .finally(() => setLoadingPrestataire(false));
-  }, [user, token]);
+  }, [user]);
 
   useEffect(() => {
     const fetchSlots = async () => {
       try {
-        const res = await api.get("/plannings", {
-          headers: { Authorization: `Bearer ${token}` },
-        });
+        const res = await api.get("/plannings");
         const formatted = res.data.map((s) => {
           const value = `${s.date_disponible}T${s.heure_debut.slice(0, 5)}`;
           return {
@@ -57,7 +53,7 @@ export default function PublierPrestation() {
     };
 
     fetchSlots();
-  }, [token]);
+  }, []);
 
   const handleChange = (e) => {
     const { name, value } = e.target;
@@ -87,8 +83,7 @@ export default function PublierPrestation() {
             ? Number(form.duree_estimee)
             : null,
           tarif: Number(form.tarif),
-        },
-        { headers: { Authorization: `Bearer ${token}` } }
+        }
       );
       setSuccess(true);
       setMessage("Prestation publiée avec succès.");

--- a/packages/frontend/frontoffice/src/pages/ReserverAnnonce.jsx
+++ b/packages/frontend/frontoffice/src/pages/ReserverAnnonce.jsx
@@ -6,7 +6,7 @@ import { useAuth } from "../context/AuthContext";
 
 export default function ReserverAnnonce() {
   const { annonceId } = useParams();
-  const { token, user } = useAuth();
+  const { user } = useAuth();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
 
@@ -24,7 +24,6 @@ export default function ReserverAnnonce() {
     const fetchAnnonce = async () => {
       try {
         const res = await api.get(`/annonces/${annonceId}`, {
-          headers: { Authorization: `Bearer ${token}` },
         });
         setAnnonce(res.data);
       } catch (err) {
@@ -35,7 +34,6 @@ export default function ReserverAnnonce() {
     const fetchEntrepots = async () => {
       try {
         const res = await api.get("/entrepots", {
-          headers: { Authorization: `Bearer ${token}` },
         });
         setEntrepots(res.data);
       } catch (err) {
@@ -45,7 +43,7 @@ export default function ReserverAnnonce() {
 
     fetchAnnonce();
     fetchEntrepots();
-  }, [annonceId, token, user, navigate]);
+  }, [annonceId, user, navigate]);
 
   useEffect(() => {
     if (searchParams.get("cancel") === "1") {
@@ -65,7 +63,6 @@ export default function ReserverAnnonce() {
     setMessage("");
     try {
       const res = await api.get(`/annonces/${annonceId}`, {
-        headers: { Authorization: `Bearer ${token}` },
       });
       if (res.data.id_client !== null || res.data.entrepot_arrivee_id !== null) {
         setMessage("Cette annonce a déjà été réservée par un autre client.");
@@ -77,7 +74,7 @@ export default function ReserverAnnonce() {
       localStorage.setItem("reservationAnnonceId", annonceId);
       const { checkout_url } = await createCheckoutSession(
         { annonce_id: Number(annonceId), type: annonce.type },
-        token,
+        
         "reserver",
       );
       window.location.href = checkout_url;

--- a/packages/frontend/frontoffice/src/pages/SuiviAnnonce.jsx
+++ b/packages/frontend/frontoffice/src/pages/SuiviAnnonce.jsx
@@ -5,7 +5,7 @@ import { useAuth } from "../context/AuthContext";
 
 export default function SuiviAnnonce() {
   const { annonceId } = useParams();
-  const { token, user } = useAuth();
+  const { user } = useAuth();
   const [annonce, setAnnonce] = useState(null);
   const [code, setCode] = useState("");
   const [message, setMessage] = useState("");
@@ -14,9 +14,7 @@ export default function SuiviAnnonce() {
 
   const fetchAnnonce = async () => {
     try {
-      const res = await api.get(`/annonces/${annonceId}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const res = await api.get(`/annonces/${annonceId}`);
       setAnnonce(res.data);
     } catch (err) {
       console.error("Erreur chargement annonce:", err);
@@ -24,10 +22,8 @@ export default function SuiviAnnonce() {
   };
 
   useEffect(() => {
-    if (token) {
-      fetchAnnonce();
-    }
-  }, [token, annonceId]);
+    fetchAnnonce();
+  }, [annonceId]);
 
   if (!annonce || !user) return <p className="text-center mt-10">Chargement...</p>;
 
@@ -82,7 +78,7 @@ export default function SuiviAnnonce() {
       await api.post(
         "/valider-code-box",
         { code, type, etape_id },
-        { headers: { Authorization: `Bearer ${token}` } }
+        
       );
       setEtatCode("success");
       setMessage("✅ Code validé avec succès.");

--- a/packages/frontend/frontoffice/src/pages/ValidationCodeBox.jsx
+++ b/packages/frontend/frontoffice/src/pages/ValidationCodeBox.jsx
@@ -8,7 +8,7 @@ export default function ValidationCodeBox() {
   const [searchParams] = useSearchParams();
   const queryType = searchParams.get("type");
   const navigate = useNavigate();
-  const { token, user } = useAuth();
+  const { user } = useAuth();
 
   const [code, setCode] = useState("");
   const [message, setMessage] = useState(null);
@@ -20,7 +20,6 @@ export default function ValidationCodeBox() {
   const fetchEtapeInfos = async () => {
     try {
       const res = await api.get(`/etapes/${id}`, {
-        headers: { Authorization: `Bearer ${token}` },
       });
 
       const e = res.data;
@@ -69,7 +68,7 @@ export default function ValidationCodeBox() {
 
   useEffect(() => {
     fetchEtapeInfos();
-  }, [id, token, user]);
+  }, [id, user]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -86,7 +85,6 @@ export default function ValidationCodeBox() {
           etape_id: id,
         },
         {
-          headers: { Authorization: `Bearer ${token}` },
         }
       );
 
@@ -103,7 +101,6 @@ export default function ValidationCodeBox() {
         }
       } else {
         await api.patch(`/etapes/${id}/cloturer`, null, {
-          headers: { Authorization: `Bearer ${token}` },
         });
         alert("✅ Colis déposé. Étape clôturée.");
         navigate("/mes-etapes");

--- a/packages/frontend/frontoffice/src/pages/client/MesPaiements.jsx
+++ b/packages/frontend/frontoffice/src/pages/client/MesPaiements.jsx
@@ -3,7 +3,7 @@ import { useAuth } from "../../context/AuthContext";
 import { fetchPaiements } from "../../services/paiement";
 
 export default function MesPaiements() {
-  const { token } = useAuth();
+  useAuth();
   const [paiements, setPaiements] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -11,7 +11,7 @@ export default function MesPaiements() {
   useEffect(() => {
     const load = async () => {
       try {
-        const data = await fetchPaiements(token);
+        const data = await fetchPaiements();
         setPaiements(data);
       } catch (err) {
         console.error(err);
@@ -21,7 +21,7 @@ export default function MesPaiements() {
       }
     };
     load();
-  }, [token]);
+  }, []);
 
   if (loading) return <p className="p-4">Chargement...</p>;
   if (error) return <p className="text-red-600 p-4">{error}</p>;

--- a/packages/frontend/frontoffice/src/routes/GuestRoute.jsx
+++ b/packages/frontend/frontoffice/src/routes/GuestRoute.jsx
@@ -3,9 +3,9 @@ import PropTypes from "prop-types";
 import { useAuth } from "../context/AuthContext";
 
 export default function GuestRoute({ children }) {
-  const { user, token } = useAuth();
+  const { user } = useAuth();
 
-  return user || token ? <Navigate to="/" replace /> : children;
+  return user ? <Navigate to="/" replace /> : children;
 }
 
 GuestRoute.propTypes = {

--- a/packages/frontend/frontoffice/src/routes/PrivateRoute.jsx
+++ b/packages/frontend/frontoffice/src/routes/PrivateRoute.jsx
@@ -3,10 +3,10 @@ import { useAuth } from "../context/AuthContext";
 import PropTypes from "prop-types";
 
 export default function PrivateRoute({ children }) {
-  const { token } = useAuth();
+  const { user } = useAuth();
 
-  // Redirection vers /login si pas de token
-  return token ? children : <Navigate to="/login" replace />;
+  // Redirection vers /login si pas connecté
+  return user ? children : <Navigate to="/login" replace />;
 }
 
 PrivateRoute.propTypes = {

--- a/packages/frontend/frontoffice/src/services/paiement.js
+++ b/packages/frontend/frontoffice/src/services/paiement.js
@@ -1,17 +1,14 @@
 import api from "./api";
 
-export async function createCheckoutSession(payload, token, context) {
+export async function createCheckoutSession(payload, _unused, context) {
   const res = await api.post(
     `/paiements/checkout-session?context=${context}`,
     payload,
-    { headers: { Authorization: `Bearer ${token}` } }
   );
   return res.data;
 }
 
-export async function fetchPaiements(token) {
-  const res = await api.get("/paiements", {
-    headers: { Authorization: `Bearer ${token}` },
-  });
+export async function fetchPaiements() {
+  const res = await api.get("/paiements");
   return res.data;
 }


### PR DESCRIPTION
## Summary
- authenticate with Sanctum session cookies
- remove token-based auth from React apps
- call Sanctum CSRF endpoint before login
- clean up API helpers and routes

## Testing
- `phpunit --version` *(fails: command not found)*
- `npm test` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_6873e82a81e88331996a3351dc96d9e3