### PR TITLE
Add /me API endpoint

### DIFF
--- a/packages/backend/routes/api.php
+++ b/packages/backend/routes/api.php
@@ -38,6 +38,24 @@ use App\Http\Controllers\PublicController;
 Route::post('/login', [AuthController::class, 'login']);
 Route::post('/register', [AuthController::class, 'register']);
 
+// Informations sur l'utilisateur actuellement connecté
+Route::middleware('auth:sanctum')->get('/me', function (Request $request) {
+    return response()->json(
+        $request->user()->only([
+            'id',
+            'nom',
+            'prenom',
+            'email',
+            'identifiant',
+            'role',
+            'pays',
+            'telephone',
+            'adresse_postale',
+            'tutorial_done',
+        ])
+    );
+});
+
 // Route de confirmation de l'email (sans authentification)
 Route::get('/verify-email/{id}/{hash}', [EmailVerificationController::class, 'verify'])
     ->middleware('signed')


### PR DESCRIPTION
## Summary
- add `/me` route under `auth:sanctum` middleware to expose current user info

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6873f55dae748331885e85b4bb2a31c1