### PR TITLE
Add /me check on React mount

### DIFF
--- a/packages/frontend/backoffice/src/context/AuthContext.jsx
+++ b/packages/frontend/backoffice/src/context/AuthContext.jsx
@@ -1,10 +1,26 @@
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useState, useEffect } from "react";
 import api from "../services/api";
 
 const AuthContext = createContext();
 
 export function AuthProvider({ children }) {
-  const [user, setUser] = useState(() => JSON.parse(localStorage.getItem("user")));
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const res = await api.get("/me");
+        setUser(res.data);
+      } catch {
+        setUser(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchUser();
+  }, []);
 
   const login = async (identifiant, password) => {
     await api.get("/sanctum/csrf-cookie");
@@ -18,7 +34,6 @@ export function AuthProvider({ children }) {
     }
 
     setUser(user);
-    localStorage.setItem("user", JSON.stringify(user));
   };
 
   const logout = async () => {
@@ -28,12 +43,11 @@ export function AuthProvider({ children }) {
       console.error("Erreur lors de la déconnexion:", err);
     } finally {
       setUser(null);
-      localStorage.removeItem("user");
     }
   };
 
   return (
-    <AuthContext.Provider value={{ user, login, logout }}>
+    <AuthContext.Provider value={{ user, loading, login, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/packages/frontend/backoffice/src/routes/PrivateRoute.jsx
+++ b/packages/frontend/backoffice/src/routes/PrivateRoute.jsx
@@ -3,7 +3,9 @@ import { useAuth } from "../context/AuthContext";
 import PropTypes from "prop-types";
 
 export default function PrivateRoute({ children }) {
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
+
+  if (loading) return <p>Chargement...</p>;
 
   // Redirection vers /login si pas connecté
   return user ? children : <Navigate to="/login" replace />;

--- a/packages/frontend/frontoffice/src/context/AuthContext.jsx
+++ b/packages/frontend/frontoffice/src/context/AuthContext.jsx
@@ -1,10 +1,26 @@
-import { createContext, useContext, useState } from "react";
+import { createContext, useContext, useState, useEffect } from "react";
 import api from "../services/api";
 
 const AuthContext = createContext();
 
 export function AuthProvider({ children }) {
-  const [user, setUser] = useState(() => JSON.parse(localStorage.getItem("user")));
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const res = await api.get("/me");
+        setUser(res.data);
+      } catch {
+        setUser(null);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchUser();
+  }, []);
 
   const login = async (email, password) => {
     await api.get("/sanctum/csrf-cookie");
@@ -12,8 +28,6 @@ export function AuthProvider({ children }) {
     const user = res.data.user;
 
     setUser(user);
-
-    localStorage.setItem("user", JSON.stringify(user));
   };
 
   const logout = async () => {
@@ -23,7 +37,6 @@ export function AuthProvider({ children }) {
       console.error("Erreur lors de la déconnexion:", err);
     } finally {
       setUser(null);
-      localStorage.removeItem("user");
     }
   };
 
@@ -40,11 +53,10 @@ export function AuthProvider({ children }) {
   const updateUser = (data) => {
     const updated = { ...user, ...data };
     setUser(updated);
-    localStorage.setItem("user", JSON.stringify(updated));
   };
 
   return (
-    <AuthContext.Provider value={{ user, login, logout, updateUser, completeTutorial }}>
+    <AuthContext.Provider value={{ user, loading, login, logout, updateUser, completeTutorial }}>
       {children}
     </AuthContext.Provider>
   );

--- a/packages/frontend/frontoffice/src/routes/PrivateRoute.jsx
+++ b/packages/frontend/frontoffice/src/routes/PrivateRoute.jsx
@@ -3,7 +3,9 @@ import { useAuth } from "../context/AuthContext";
 import PropTypes from "prop-types";
 
 export default function PrivateRoute({ children }) {
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
+
+  if (loading) return <p>Chargement...</p>;
 
   // Redirection vers /login si pas connecté
   return user ? children : <Navigate to="/login" replace />;


### PR DESCRIPTION
## Summary
- auto-load user session from `/me` in front- and backoffice AuthContext
- use loading state in PrivateRoute to avoid redirect before session check

## Testing
- `npm run lint` *(fails: 7 errors, 8 warnings)* for frontoffice
- `npm run lint` *(passes with warnings)* for backoffice

------
https://chatgpt.com/codex/tasks/task_e_6873f805cfe883318fb73253f2b933b6