### PR TITLE
Fix Axios CSRF settings

### DIFF
--- a/packages/frontend/backoffice/src/context/AuthContext.jsx
+++ b/packages/frontend/backoffice/src/context/AuthContext.jsx
@@ -23,7 +23,9 @@ export function AuthProvider({ children }) {
   }, []);
 
   const login = async (identifiant, password) => {
-    await api.get("/sanctum/csrf-cookie");
+    await api.get("/sanctum/csrf-cookie", {
+      baseURL: api.defaults.baseURL.replace("/api", ""),
+    });
     const res = await api.post("/login", { identifiant, password });
 
     const user = res.data.user;

--- a/packages/frontend/backoffice/src/services/api.js
+++ b/packages/frontend/backoffice/src/services/api.js
@@ -3,6 +3,8 @@ import axios from "axios";
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL,
   withCredentials: true,
+  xsrfCookieName: "XSRF-TOKEN",
+  xsrfHeaderName: "X-XSRF-TOKEN",
   headers: {
     "Content-Type": "application/json",
     Accept: "application/json",


### PR DESCRIPTION
## Summary
- configure axios instance to send XSRF token automatically
- request csrf-cookie without API prefix

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6873fc85013083318f54393b3506e9cb