### PR TITLE
Fix Sanctum SPA session

### DIFF
--- a/packages/backend/.env.production
+++ b/packages/backend/.env.production
@@ -21,6 +21,8 @@ FILESYSTEM_DISK=local # TODO: mettre public en prod
 QUEUE_CONNECTION=sync
 SESSION_DRIVER=file
 SESSION_LIFETIME=120
+SESSION_SAME_SITE=lax
+SESSION_SECURE_COOKIE=false
 
 SANCTUM_STATEFUL_DOMAINS=localhost:5173,localhost:6174 # TODO: mettre les domaines frontoffice/backoffice en production
 SESSION_DOMAIN=localhost

--- a/packages/backend/routes/api.php
+++ b/packages/backend/routes/api.php
@@ -35,7 +35,6 @@ use App\Http\Controllers\TrajetLivreurController;
 use App\Http\Controllers\PublicController;
 
 // Authentification
-Route::post('/login', [AuthController::class, 'login']);
 Route::post('/register', [AuthController::class, 'register']);
 
 // Informations sur l'utilisateur actuellement connecté
@@ -291,6 +290,5 @@ Route::middleware('auth:sanctum')->group(function () {
     // Route::post('/user/2fa/enable', [TwoFactorController::class, 'enable']);
     // Route::post('/user/2fa/disable', [TwoFactorController::class, 'disable']);
 
-    // Déconnexion
-    Route::post('/logout', [AuthController::class, 'logout']);
+    // Déconnexion - gérée via les routes web pour bénéficier de la session
 });

--- a/packages/backend/routes/web.php
+++ b/packages/backend/routes/web.php
@@ -1,7 +1,14 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AuthController;
 
 Route::get('/', function () {
     return view('welcome');
+});
+
+// Routes d'authentification pour le mode SPA
+Route::middleware('web')->group(function () {
+    Route::post('/login', [AuthController::class, 'login']);
+    Route::post('/logout', [AuthController::class, 'logout'])->middleware('auth:sanctum');
 });


### PR DESCRIPTION
## Summary
- move `/login` & `/logout` routes to the web middleware so Sanctum can use sessions
- remove login route from API routes
- specify local session settings in `.env.production`

## Testing
- `composer install --no-interaction --no-progress`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6874033bdb888331bb279da99edbcaf0