### PR TITLE
Fix backoffice login endpoint

### DIFF
--- a/packages/frontend/backoffice/src/context/AuthContext.jsx
+++ b/packages/frontend/backoffice/src/context/AuthContext.jsx
@@ -23,10 +23,18 @@ export function AuthProvider({ children }) {
   }, []);
 
   const login = async (identifiant, password) => {
+    // Laravel Sanctum nécessite d'abord la récupération du cookie CSRF
     await api.get("/sanctum/csrf-cookie", {
       baseURL: api.defaults.baseURL.replace("/api", ""),
     });
-    const res = await api.post("/login", { identifiant, password });
+
+    // L'endpoint /login n'est pas préfixé par /api :
+    // on surcharge donc temporairement baseURL pour cette requête
+    const res = await api.post(
+      "/login",
+      { identifiant, password },
+      { baseURL: api.defaults.baseURL.replace("/api", "") }
+    );
 
     const user = res.data.user;
 


### PR DESCRIPTION
## Summary
- ensure the login request hits `/login` without the `/api` prefix so Sanctum session can start

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6874072a01d88331ad79619d982d6804