### PR TITLE
Update CORS settings for public IP

### DIFF
--- a/packages/backend/.env.production
+++ b/packages/backend/.env.production
@@ -1,7 +1,7 @@
 APP_NAME=EcoDeli
-APP_ENV=local # TODO: mettre production en prod
+APP_ENV=production
 APP_KEY=base64:CYz02DqJUFb5qOWmYLGqngyHCJMKt7A1yKlYnAPNql8= # TODO: régénérer avec php artisan key:generate en production
-APP_DEBUG=true # TODO: mettre false en prod
+APP_DEBUG=false
 APP_URL=http://127.0.0.1:8000 # TODO: mettre l’URL publique réelle du backend
 
 LOG_CHANNEL=stack
@@ -22,10 +22,11 @@ QUEUE_CONNECTION=sync
 SESSION_DRIVER=file
 SESSION_LIFETIME=120
 
-SANCTUM_STATEFUL_DOMAINS=localhost:5173,localhost:6174 # TODO: mettre les domaines frontoffice/backoffice en production
+SANCTUM_STATEFUL_DOMAINS=51.83.25.53:5173,51.83.25.53:6174
 SESSION_DOMAIN=localhost
 
 STRIPE_PUBLIC_KEY=pk_test_51RdsclCoqQVCmYp35pDOWNNbqDg1ySdb6dXtRvf0DvlpQbyNzZdSBp9xIAouIoQ6loY2AicDN8qqfAURL87emPSt00uvAXLjWy # TODO: mettre la vraie clé Stripe live
 STRIPE_SECRET_KEY=sk_test_51RdsclCoqQVCmYp3r42ZB9CKTAP1mtAJkXfCsV3WRePgigsyluoC5oCnO0qo4VnvvGpZOX4CSMJoz8qzbhYETC9R00oly3mMWS # TODO: mettre la vraie clé Stripe LIVE
 
-FRONTEND_URL=http://localhost:5173 # TODO: mettre l'URL publique du frontoffice
+FRONTEND_URL=http://51.83.25.53:5173
+// TODO: replace IP with domain when available in SANCTUM_STATEFUL_DOMAINS and FRONTEND_URL

--- a/packages/backend/config/cors.php
+++ b/packages/backend/config/cors.php
@@ -3,7 +3,12 @@
 return [
     'paths' => ['api/*', 'sanctum/csrf-cookie', 'login', 'register'],
     'allowed_methods' => ['*'],
-    'allowed_origins' => ['http://localhost:5173', 'http://localhost:6174'],
+    'allowed_origins' => [
+        'http://localhost:5173',
+        'http://localhost:6174',
+        'http://51.83.25.53:5173',
+        'http://51.83.25.53:6174',
+    ],
     'allowed_headers' => ['*'],
     'max_age' => 0,
     'supports_credentials' => true,


### PR DESCRIPTION
## Summary
- allow frontend and backoffice IPs in CORS config
- set production defaults in `.env.production`
- note that the IP should be replaced by a domain later

## Testing
- `composer install`
- `vendor/bin/phpunit --stop-on-failure` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_687421b5df1883319917d800ecc81dc6