### PR TITLE
Display annonce images in detail pages

### DIFF
--- a/packages/frontend/frontoffice/src/pages/AnnonceDetail.jsx
+++ b/packages/frontend/frontoffice/src/pages/AnnonceDetail.jsx
@@ -3,6 +3,8 @@ import { useParams, useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import api from "../services/api";
 
+const STORAGE_BASE_URL = api.defaults.baseURL.replace("/api", "");
+
 export default function AnnonceDetail() {
   const { id } = useParams();
   const navigate = useNavigate();
@@ -34,6 +36,13 @@ export default function AnnonceDetail() {
   return (
     <div className="max-w-2xl mx-auto mt-10 p-6 bg-white shadow rounded">
       <h2 className="text-2xl font-bold mb-4">{annonce.titre}</h2>
+      {annonce.photo && (
+        <img
+          src={`${STORAGE_BASE_URL}/storage/${annonce.photo}`}
+          alt="Photo de l’annonce"
+          className="mb-4 max-w-full h-auto"
+        />
+      )}
       <p className="mb-2">{annonce.description}</p>
       <p className="mb-2">
         <strong>Prix :</strong> {annonce.prix_propose} €

--- a/packages/frontend/frontoffice/src/pages/AnnonceDetailPublic.jsx
+++ b/packages/frontend/frontoffice/src/pages/AnnonceDetailPublic.jsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import api from "../services/api";
 
+const STORAGE_BASE_URL = api.defaults.baseURL.replace("/api", "");
+
 export default function AnnonceDetailPublic() {
   const { id } = useParams();
   const navigate = useNavigate();
@@ -31,6 +33,13 @@ export default function AnnonceDetailPublic() {
   return (
     <div className="max-w-2xl mx-auto mt-10 p-6 bg-white shadow rounded">
       <h2 className="text-2xl font-bold mb-4">{annonce.titre}</h2>
+      {annonce.photo && (
+        <img
+          src={`${STORAGE_BASE_URL}/storage/${annonce.photo}`}
+          alt="Photo de l’annonce"
+          className="mb-4 max-w-full h-auto"
+        />
+      )}
       <p className="mb-2">{annonce.description}</p>
       <p className="mb-2">
         <strong>Prix :</strong> {annonce.prix_propose} €


### PR DESCRIPTION
## Summary
- show annonce photos in detail pages if provided

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js' before install; after install, lint errors unrelated to changes)*

------
https://chatgpt.com/codex/tasks/task_e_6874d687eca08331a91d5a2ccc81cd4d