### PR TITLE
Set Sendinblue SMTP settings

### DIFF
--- a/packages/backend/.env.production
+++ b/packages/backend/.env.production
@@ -15,7 +15,14 @@ DB_USERNAME=nicusolalkatherine
 DB_PASSWORD=nicusolalkatherine20
 
 BROADCAST_DRIVER=log
-MAIL_MAILER=log
+MAIL_MAILER=smtp
+MAIL_HOST=smtp-relay.brevo.com
+MAIL_PORT=587
+MAIL_USERNAME=920d93001@smtp-brevo.com
+MAIL_PASSWORD=49KpMBmtATy8XDbc
+MAIL_ENCRYPTION=tls
+MAIL_FROM_ADDRESS=no-reply@ecodeli.fr
+MAIL_FROM_NAME="EcoDeli"
 CACHE_DRIVER=file
 FILESYSTEM_DISK=local # TODO: mettre public en prod
 QUEUE_CONNECTION=sync


### PR DESCRIPTION
## Summary
- configure production mailer to use Sendinblue SMTP service

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit --no-coverage`


------
https://chatgpt.com/codex/tasks/task_e_6874f16c932c8331970195408008a8f9