### PR TITLE
Add email verification info to login

### DIFF
--- a/packages/backend/app/Http/Controllers/AuthController.php
+++ b/packages/backend/app/Http/Controllers/AuthController.php
@@ -74,6 +74,7 @@ class AuthController extends Controller
                 'nom' => $user->nom,
                 'prenom' => $user->prenom,
                 'email' => $user->email,
+                'email_verified_at' => $user->email_verified_at,
                 'identifiant' => $user->identifiant,
                 'role' => $user->role,
                 'pays' => $user->pays,


### PR DESCRIPTION
## Summary
- expose `email_verified_at` in login response

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6875023a2f5c83319e9b0cedf79f186e