### PR TITLE
Refactor livreur justificatifs management

### DIFF
--- a/packages/backend/app/Http/Controllers/LivreurValidationController.php
+++ b/packages/backend/app/Http/Controllers/LivreurValidationController.php
@@ -3,8 +3,10 @@
 namespace App\Http\Controllers;
 
 use App\Models\Livreur;
+use App\Models\JustificatifLivreur;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
 
 class LivreurValidationController extends Controller
 {
@@ -60,6 +62,13 @@ class LivreurValidationController extends Controller
         $livreur->statut = 'refuse';
         $livreur->motif_refus = $validated['motif_refus'] ?? null;
         $livreur->save();
+
+        // Supprimer tous les justificatifs existants
+        $docs = $livreur->justificatifs;
+        foreach ($docs as $doc) {
+            Storage::disk('public')->delete($doc->chemin);
+            $doc->delete();
+        }
 
         return response()->json(['message' => 'Livreur refusé.']);
     }

--- a/packages/backend/app/Models/JustificatifLivreur.php
+++ b/packages/backend/app/Models/JustificatifLivreur.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class JustificatifLivreur extends Model
+{
+    use HasFactory;
+
+    protected $table = 'justificatifs_livreurs';
+
+    protected $fillable = [
+        'livreur_id',
+        'chemin',
+        'type',
+        'statut',
+    ];
+
+    public function livreur()
+    {
+        return $this->belongsTo(Livreur::class);
+    }
+}

--- a/packages/backend/app/Models/Livreur.php
+++ b/packages/backend/app/Models/Livreur.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\JustificatifLivreur;
 
 class Livreur extends Model
 {
@@ -23,5 +24,10 @@ class Livreur extends Model
     public function utilisateur()
     {
         return $this->belongsTo(Utilisateur::class);
+    }
+
+    public function justificatifs()
+    {
+        return $this->hasMany(JustificatifLivreur::class);
     }
 }

--- a/packages/backend/database/migrations/2025_09_08_000004_create_justificatifs_livreurs_table.php
+++ b/packages/backend/database/migrations/2025_09_08_000004_create_justificatifs_livreurs_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('justificatifs_livreurs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('livreur_id')->constrained()->onDelete('cascade');
+            $table->string('chemin');
+            $table->string('type')->nullable();
+            $table->string('statut')->default('en_attente');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('justificatifs_livreurs');
+    }
+};

--- a/packages/backend/routes/api.php
+++ b/packages/backend/routes/api.php
@@ -116,7 +116,7 @@ Route::middleware(['auth:sanctum', 'role:admin,livreur'])->group(function () {
     Route::patch('/livreurs/{id}', [LivreurController::class, 'update'])->whereNumber('id');
     Route::get('/livreurs/{id}/justificatifs', [JustificatifLivreurController::class, 'index'])->whereNumber('id');
     Route::post('/livreurs/justificatifs', [JustificatifLivreurController::class, 'store']);
-    Route::delete('/livreurs/justificatifs/{type}', [JustificatifLivreurController::class, 'destroy']);
+    Route::delete('/livreurs/justificatifs/{id}', [JustificatifLivreurController::class, 'destroy']);
 
     Route::middleware('livreur.valide')->group(function () {
         Route::get('/annonces-disponibles', [AnnonceController::class, 'annoncesDisponibles']);

--- a/packages/frontend/backoffice/src/pages/admin/AdminLivreur.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/AdminLivreur.jsx
@@ -6,6 +6,7 @@ const STORAGE_BASE_URL = api.defaults.baseURL.replace("/api", "");
 export default function AdminLivreur() {
   const [livreurs, setLivreurs] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [justifs, setJustifs] = useState({});
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState("");
   const [cityFilter, setCityFilter] = useState("");
@@ -24,6 +25,15 @@ export default function AdminLivreur() {
       setLoading(false);
     }
   }
+
+  const voirJustifs = async (id) => {
+    try {
+      const res = await api.get(`/livreurs/${id}/justificatifs`);
+      setJustifs((prev) => ({ ...prev, [id]: res.data }));
+    } catch (err) {
+      console.error(err);
+    }
+  };
 
   const valider = async (id) => {
     if (!window.confirm("Valider ce livreur ?")) return;
@@ -123,27 +133,10 @@ export default function AdminLivreur() {
                 <td className="p-3">{l.utilisateur?.email}</td>
                 <td className="p-3">{l.valide ? "Oui" : "Non"}</td>
                 <td className="p-3 capitalize">{l.statut}</td>
-                <td className="p-3 space-y-1">
-                  {l.piece_identite_document && (
-                    <a
-                      href={`${STORAGE_BASE_URL}/storage/${l.piece_identite_document}`}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="text-blue-600 underline block"
-                    >
-                      Pièce d'identité
-                    </a>
-                  )}
-                  {l.permis_conduire_document && (
-                    <a
-                      href={`${STORAGE_BASE_URL}/storage/${l.permis_conduire_document}`}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="text-blue-600 underline block"
-                    >
-                      Permis de conduire
-                    </a>
-                  )}
+                <td className="p-3">
+                  <button onClick={() => voirJustifs(l.utilisateur_id)} className="text-blue-600 hover:underline">
+                    Voir justificatifs
+                  </button>
                 </td>
                 <td className="p-3 text-sm">{l.motif_refus || ""}</td>
                 <td className="p-3 space-x-2">
@@ -169,6 +162,25 @@ export default function AdminLivreur() {
           </tbody>
         </table>
       </div>
+      {Object.entries(justifs).map(([id, files]) => (
+        <div key={id} className="mt-4">
+          <h2 className="font-semibold">Justificatifs utilisateur {id}</h2>
+          <ul className="list-disc ml-6">
+            {files.map((f) => (
+              <li key={f.id}>
+                <a
+                  href={`${STORAGE_BASE_URL}/storage/${f.chemin}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-blue-600 underline"
+                >
+                  {f.chemin}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
     </div>
   );
 }

--- a/packages/frontend/frontoffice/src/pages/ProfilLivreur.jsx
+++ b/packages/frontend/frontoffice/src/pages/ProfilLivreur.jsx
@@ -7,7 +7,8 @@ const STORAGE_BASE_URL = api.defaults.baseURL.replace("/api", "");
 export default function ProfilLivreur() {
   const { user, token } = useAuth();
   const [livreur, setLivreur] = useState(null);
-  const [files, setFiles] = useState({ identite: null, permis: null });
+  const [justifs, setJustifs] = useState([]);
+  const [file, setFile] = useState(null);
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState("");
 
@@ -17,6 +18,11 @@ export default function ProfilLivreur() {
       .get(`/livreurs/${user.id}`, { headers: { Authorization: `Bearer ${token}` } })
       .then((res) => setLivreur(res.data))
       .catch(() => setError("Erreur de chargement"));
+
+    api
+      .get(`/livreurs/${user.id}/justificatifs`, { headers: { Authorization: `Bearer ${token}` } })
+      .then((res) => setJustifs(res.data))
+      .catch(() => setJustifs([]));
   }, [user, token]);
 
   const statutLabel =
@@ -27,10 +33,9 @@ export default function ProfilLivreur() {
       : "En attente";
 
   const handleUpload = async () => {
-    if (!files.identite && !files.permis) return;
+    if (!file) return;
     const data = new FormData();
-    if (files.identite) data.append("piece_identite_document", files.identite);
-    if (files.permis) data.append("permis_conduire_document", files.permis);
+    data.append("fichier", file);
     setUploading(true);
     try {
       const res = await api.post("/livreurs/justificatifs", data, {
@@ -39,11 +44,12 @@ export default function ProfilLivreur() {
           "Content-Type": "multipart/form-data",
         },
       });
-      setLivreur(res.data.livreur);
-      alert(
-        "\u2705 Vos documents ont bien été reçus. Votre profil repasse en validation."
-      );
-      setFiles({ identite: null, permis: null });
+      setJustifs((prev) => [...prev, res.data]);
+      if (livreur.statut === "refuse") {
+        setLivreur((l) => ({ ...l, statut: "en_attente", motif_refus: null }));
+      }
+      alert("\u2705 Document envoyé.");
+      setFile(null);
     } catch {
       setError("Erreur lors de l'envoi du fichier");
     } finally {
@@ -51,16 +57,13 @@ export default function ProfilLivreur() {
     }
   };
 
-  const handleDelete = async (type) => {
+  const handleDelete = async (id) => {
     if (!window.confirm("Supprimer ce document ?")) return;
     try {
-      await api.delete(`/livreurs/justificatifs/${type}`, {
+      await api.delete(`/livreurs/justificatifs/${id}`, {
         headers: { Authorization: `Bearer ${token}` },
       });
-      setLivreur((prev) => ({
-        ...prev,
-        [`${type}_document`]: null,
-      }));
+      setJustifs((prev) => prev.filter((j) => j.id !== id));
     } catch {
       alert("Suppression impossible");
     }
@@ -86,71 +89,38 @@ export default function ProfilLivreur() {
       <div className="mt-6 space-y-2">
         <h3 className="text-lg font-semibold">Mes justificatifs</h3>
         <ul className="space-y-2 mb-4">
-          {livreur.piece_identite_document && (
-            <li className="border p-2 rounded flex justify-between items-center">
+          {justifs.map((j) => (
+            <li key={j.id} className="border p-2 rounded flex justify-between items-center">
               <a
-                href={`${STORAGE_BASE_URL}/storage/${livreur.piece_identite_document}`}
+                href={`${STORAGE_BASE_URL}/storage/${j.chemin}`}
                 target="_blank"
                 rel="noreferrer"
                 className="text-blue-600 underline"
               >
-                Pièce d'identité
+                {j.type || j.chemin}
               </a>
               {livreur.statut === "refuse" && (
                 <button
-                  onClick={() => handleDelete("piece_identite")}
+                  onClick={() => handleDelete(j.id)}
                   className="text-sm text-red-600 hover:underline"
                 >
                   Supprimer
                 </button>
               )}
             </li>
-          )}
-          {livreur.permis_conduire_document && (
-            <li className="border p-2 rounded flex justify-between items-center">
-              <a
-                href={`${STORAGE_BASE_URL}/storage/${livreur.permis_conduire_document}`}
-                target="_blank"
-                rel="noreferrer"
-                className="text-blue-600 underline"
-              >
-                Permis de conduire
-              </a>
-              {livreur.statut === "refuse" && (
-                <button
-                  onClick={() => handleDelete("permis_conduire")}
-                  className="text-sm text-red-600 hover:underline"
-                >
-                  Supprimer
-                </button>
-              )}
-            </li>
-          )}
+          ))}
         </ul>
         {livreur.statut === "refuse" && (
           <>
-            {livreur.piece_identite_document || livreur.permis_conduire_document ? (
+            {justifs.some((j) => j.statut === "refuse") ? (
               <p className="text-sm text-gray-600">
-                📂 Vous devez supprimer les justificatifs refusés avant d’en
-                ajouter un nouveau.
+                📂 Vous devez supprimer les justificatifs refusés avant d’en ajouter un nouveau.
               </p>
             ) : (
               <>
-                <label className="block font-medium">Pièce d'identité</label>
                 <input
                   type="file"
-                  onChange={(e) =>
-                    setFiles((f) => ({ ...f, identite: e.target.files[0] }))
-                  }
-                  className="mb-2 block"
-                />
-
-                <label className="block font-medium">Permis de conduire</label>
-                <input
-                  type="file"
-                  onChange={(e) =>
-                    setFiles((f) => ({ ...f, permis: e.target.files[0] }))
-                  }
+                  onChange={(e) => setFile(e.target.files[0])}
                   className="mb-2 block"
                 />
                 <button


### PR DESCRIPTION
## Summary
- unify justificatif logic for *livreurs*
- add `justificatifs_livreurs` table and model
- update controller and routes
- purge documents when admin refuses a livreur
- adjust frontend pages to use new API

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: Missing APP_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_6875235c545083318f1f433606478bef