### PR TITLE
Nettoyage des commentaires générés et des emojis

### DIFF
--- a/packages/backend/app/Actions/Fortify/CreateNewUser.php
+++ b/packages/backend/app/Actions/Fortify/CreateNewUser.php
@@ -12,11 +12,6 @@ class CreateNewUser implements CreatesNewUsers
 {
     use PasswordValidationRules;
 
-    /**
-     * Validate and create a newly registered user.
-     *
-     * @param  array<string, string>  $input
-     */
     public function create(array $input): User
     {
         Validator::make($input, [

--- a/packages/backend/app/Actions/Fortify/PasswordValidationRules.php
+++ b/packages/backend/app/Actions/Fortify/PasswordValidationRules.php
@@ -6,11 +6,6 @@ use Illuminate\Validation\Rules\Password;
 
 trait PasswordValidationRules
 {
-    /**
-     * Get the validation rules used to validate passwords.
-     *
-     * @return array<int, \Illuminate\Contracts\Validation\Rule|array<mixed>|string>
-     */
     protected function passwordRules(): array
     {
         return ['required', 'string', Password::default(), 'confirmed'];

--- a/packages/backend/app/Actions/Fortify/ResetUserPassword.php
+++ b/packages/backend/app/Actions/Fortify/ResetUserPassword.php
@@ -11,11 +11,6 @@ class ResetUserPassword implements ResetsUserPasswords
 {
     use PasswordValidationRules;
 
-    /**
-     * Validate and reset the user's forgotten password.
-     *
-     * @param  array<string, string>  $input
-     */
     public function reset(User $user, array $input): void
     {
         Validator::make($input, [

--- a/packages/backend/app/Actions/Fortify/UpdateUserPassword.php
+++ b/packages/backend/app/Actions/Fortify/UpdateUserPassword.php
@@ -11,11 +11,6 @@ class UpdateUserPassword implements UpdatesUserPasswords
 {
     use PasswordValidationRules;
 
-    /**
-     * Validate and update the user's password.
-     *
-     * @param  array<string, string>  $input
-     */
     public function update(User $user, array $input): void
     {
         Validator::make($input, [

--- a/packages/backend/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/packages/backend/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -10,11 +10,6 @@ use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
 
 class UpdateUserProfileInformation implements UpdatesUserProfileInformation
 {
-    /**
-     * Validate and update the given user's profile information.
-     *
-     * @param  array<string, string>  $input
-     */
     public function update(User $user, array $input): void
     {
         Validator::make($input, [
@@ -40,11 +35,6 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
         }
     }
 
-    /**
-     * Update the given verified user's profile information.
-     *
-     * @param  array<string, string>  $input
-     */
     protected function updateVerifiedUser(User $user, array $input): void
     {
         $user->forceFill([

--- a/packages/backend/app/Exceptions/Handler.php
+++ b/packages/backend/app/Exceptions/Handler.php
@@ -8,35 +8,19 @@ use Throwable;
 
 class Handler extends ExceptionHandler
 {
-    /**
-     * Liste des exceptions non signalées.
-     *
-     * @var array<int, class-string<Throwable>>
-     */
     protected $dontReport = [];
 
-    /**
-     * Liste des inputs jamais flashés pour la validation.
-     *
-     * @var array<int, string>
-     */
     protected $dontFlash = [
         'current_password',
         'password',
         'password_confirmation',
     ];
 
-    /**
-     * Gérer une exception non authentifiée (API).
-     */
     protected function unauthenticated($request, AuthenticationException $exception)
     {
         return response()->json(['message' => 'Non authentifié.'], 401);
     }
 
-    /**
-     * Enregistre les callbacks pour la gestion des exceptions.
-     */
     public function register(): void
     {
         $this->reportable(function (Throwable $e) {

--- a/packages/backend/app/Http/Controllers/BoxController.php
+++ b/packages/backend/app/Http/Controllers/BoxController.php
@@ -7,9 +7,6 @@ use Illuminate\Http\Request;
 
 class BoxController extends Controller
 {
-    /**
-     * Lister toutes les boxes (optionnellement par entrepôt).
-     */
     public function index(Request $request)
     {
         $query = Box::with('entrepot');
@@ -21,9 +18,6 @@ class BoxController extends Controller
         return response()->json($query->get());
     }
 
-    /**
-     * Créer une nouvelle box dans un entrepôt.
-     */
     public function store(Request $request)
     {
         $validated = $request->validate([
@@ -44,9 +38,6 @@ class BoxController extends Controller
         ], 201);
     }
 
-    /**
-     * Mettre à jour une box.
-     */
     public function update(Request $request, $id)
     {
         $box = Box::find($id);
@@ -68,9 +59,6 @@ class BoxController extends Controller
         ]);
     }
 
-    /**
-     * Supprimer une box.
-     */
     public function destroy($id)
     {
         $box = Box::find($id);

--- a/packages/backend/app/Http/Controllers/ClientController.php
+++ b/packages/backend/app/Http/Controllers/ClientController.php
@@ -8,13 +8,11 @@ use Illuminate\Support\Facades\Auth;
 
 class ClientController extends Controller
 {
-    // Retourne tous les clients
     public function index()
     {
         return response()->json(Client::all());
     }
 
-    // Affiche un client par utilisateur_id (lié au profil utilisateur)
     public function show($id)
     {
         $client = Client::where('utilisateur_id', $id)->first();
@@ -26,7 +24,6 @@ class ClientController extends Controller
         return response()->json($client);
     }
 
-    // Met à jour un client (seulement téléphone ou adresse)
     public function update(Request $request, $id)
     {
         $client = Client::where('utilisateur_id', $id)->first();

--- a/packages/backend/app/Http/Controllers/EntrepotController.php
+++ b/packages/backend/app/Http/Controllers/EntrepotController.php
@@ -7,17 +7,11 @@ use Illuminate\Http\Request;
 
 class EntrepotController extends Controller
 {
-    /**
-     * Lister tous les entrepôts.
-     */
     public function index()
     {
         return response()->json(Entrepot::all());
     }
 
-    /**
-     * Créer un nouvel entrepôt.
-     */
     public function store(Request $request)
     {
         $validated = $request->validate([
@@ -35,9 +29,6 @@ class EntrepotController extends Controller
         ], 201);
     }
 
-    /**
-     * Afficher un entrepôt spécifique.
-     */
     public function show($id)
     {
         $entrepot = Entrepot::find($id);
@@ -49,9 +40,6 @@ class EntrepotController extends Controller
         return response()->json($entrepot);
     }
 
-    /**
-     * Modifier un entrepôt.
-     */
     public function update(Request $request, $id)
     {
         $entrepot = Entrepot::find($id);
@@ -75,9 +63,6 @@ class EntrepotController extends Controller
         ]);
     }
 
-    /**
-     * Supprimer un entrepôt.
-     */
     public function destroy($id)
     {
         $entrepot = Entrepot::find($id);

--- a/packages/backend/app/Http/Controllers/FactureController.php
+++ b/packages/backend/app/Http/Controllers/FactureController.php
@@ -12,9 +12,6 @@ use Illuminate\Support\Facades\Auth;
 
 class FactureController extends Controller
 {
-    /**
-     * Lister toutes les factures de l'utilisateur connecté.
-     */
     public function index()
     {
         $factures = Facture::where('utilisateur_id', Auth::id())->get();
@@ -22,9 +19,6 @@ class FactureController extends Controller
         return response()->json($factures);
     }
 
-    /**
-     * Créer une facture manuellement.
-     */
     public function store(Request $request)
     {
         $request->validate([
@@ -45,9 +39,6 @@ class FactureController extends Controller
         ], 201);
     }
 
-    /**
-     * Afficher une facture spécifique.
-     */
     public function show($id)
     {
         $facture = Facture::where('utilisateur_id', Auth::id())->find($id);

--- a/packages/backend/app/Http/Controllers/FacturePrestataireController.php
+++ b/packages/backend/app/Http/Controllers/FacturePrestataireController.php
@@ -21,12 +21,10 @@ class FacturePrestataireController extends Controller
             return response()->json(['message' => 'Accès réservé aux prestataires.'], 403);
         }
 
-        // Vérifier si facture déjà générée
         if (FacturePrestataire::where('prestataire_id', $prestataireId)->where('mois', $mois)->exists()) {
             return response()->json(['message' => 'Facture déjà générée pour ce mois.'], 409);
         }
 
-        // Récupérer les prestations validées du mois donné
         $interventions = Intervention::with('prestation')
             ->whereHas('prestation', function ($query) use ($mois, $prestataireId) {
                 $query->where('prestataire_id', $prestataireId)
@@ -42,7 +40,6 @@ class FacturePrestataireController extends Controller
 
         $total = $interventions->sum(fn($i) => $i->prestation->tarif);
 
-        // Générer le PDF
         $pdf = Pdf::loadView('factures.prestataire', [
             'interventions' => $interventions,
             'mois' => $mois,

--- a/packages/backend/app/Http/Controllers/InterventionController.php
+++ b/packages/backend/app/Http/Controllers/InterventionController.php
@@ -46,19 +46,14 @@ class InterventionController extends Controller
 
         $prestation = Prestation::find($validated['prestation_id']);
 
-        // Vérifier que le prestataire est bien celui lié à la prestation
         if ($prestation->prestataire_id !== ($user->prestataire->id ?? null)) {
             return response()->json(['message' => 'Accès interdit.'], 403);
         }
 
-        // Empêcher la création d'une intervention avant la date de la prestation
-        // Désactivé temporairement pour la phase de test fonctionnel
         if (Carbon::now()->lt($prestation->date_heure)) {
             Log::warning('Intervention avant date prévue', ['prestation_id' => $prestation->id]);
-            // La vérification est momentanément désactivée : on ne bloque pas la création
         }
 
-        // Empêcher la duplication d'intervention pour la même prestation
         if (Intervention::where('prestation_id', $prestation->id)->exists()) {
             Log::warning('Intervention déjà enregistrée', [
                 'prestation_id' => $prestation->id,
@@ -80,7 +75,6 @@ class InterventionController extends Controller
             'prestataire_id' => $user->prestataire->id ?? null,
         ]);
 
-        // Mettre à jour le statut de la prestation
         $prestation->statut = 'terminée';
         $prestation->save();
 

--- a/packages/backend/app/Http/Controllers/JustificatifController.php
+++ b/packages/backend/app/Http/Controllers/JustificatifController.php
@@ -35,7 +35,6 @@ class JustificatifController extends Controller
             'type_document' => 'nullable|string',
         ]);
 
-        // Supprimer les justificatifs refusés existants
         $anciens = JustificatifPrestataire::where('prestataire_id', $prestataire->id)
             ->where('statut', 'refuse')
             ->get();

--- a/packages/backend/app/Http/Controllers/JustificatifLivreurController.php
+++ b/packages/backend/app/Http/Controllers/JustificatifLivreurController.php
@@ -39,7 +39,6 @@ class JustificatifLivreurController extends Controller
 
         $livreur = $user->livreur;
 
-        // Supprimer les justificatifs refusés existants
         $anciens = JustificatifLivreur::where('livreur_id', $livreur->id)
             ->where('statut', 'refuse')
             ->get();

--- a/packages/backend/app/Http/Controllers/LivreurValidationController.php
+++ b/packages/backend/app/Http/Controllers/LivreurValidationController.php
@@ -63,7 +63,6 @@ class LivreurValidationController extends Controller
         $livreur->motif_refus = $validated['motif_refus'] ?? null;
         $livreur->save();
 
-        // Supprimer tous les justificatifs existants
         $docs = $livreur->justificatifs;
         foreach ($docs as $doc) {
             Storage::disk('public')->delete($doc->chemin);

--- a/packages/backend/app/Http/Controllers/NotificationController.php
+++ b/packages/backend/app/Http/Controllers/NotificationController.php
@@ -8,9 +8,6 @@ use Illuminate\Support\Facades\Auth;
 
 class NotificationController extends Controller
 {
-    /**
-     * Lister les notifications de l'utilisateur connecté.
-     */
     public function index()
     {
         $notifications = Notification::where('utilisateur_id', Auth::id())
@@ -20,9 +17,7 @@ class NotificationController extends Controller
         return response()->json($notifications);
     }
 
-    /**
-     * Marquer une notification comme lue.
-     */
+    
     public function markAsRead($id)
     {
         $notification = Notification::where('id', $id)
@@ -38,9 +33,6 @@ class NotificationController extends Controller
         return response()->json(['message' => 'Notification marquée comme lue.']);
     }
 
-    /**
-     * Créer une notification (ex. : par admin ou test manuel).
-     */
     public function store(Request $request)
     {
         $request->validate([

--- a/packages/backend/app/Http/Controllers/PaiementController.php
+++ b/packages/backend/app/Http/Controllers/PaiementController.php
@@ -11,9 +11,6 @@ use Stripe\StripeClient;
 
 class PaiementController extends Controller
 {
-    /**
-     * Lister les paiements de l'utilisateur connecté.
-     */
     public function index()
     {
         $utilisateur = Auth::user();
@@ -23,9 +20,6 @@ class PaiementController extends Controller
         return response()->json($paiements);
     }
 
-    /**
-     * Créer un nouveau paiement.
-     */
     public function store(Request $request)
     {
         $utilisateur = Auth::user();
@@ -53,9 +47,6 @@ class PaiementController extends Controller
         ], 201);
     }
 
-    /**
-     * Afficher un paiement spécifique.
-     */
     public function show($id)
     {
         $paiement = Paiement::find($id);
@@ -67,9 +58,6 @@ class PaiementController extends Controller
         return response()->json($paiement);
     }
 
-    /**
-     * Crée une session Stripe Checkout et renvoie son URL.
-     */
     public function createCheckoutSession(Request $request)
     {
         $validated = $request->validate([

--- a/packages/backend/app/Http/Controllers/PortefeuilleController.php
+++ b/packages/backend/app/Http/Controllers/PortefeuilleController.php
@@ -8,9 +8,6 @@ use Illuminate\Support\Facades\Auth;
 
 class PortefeuilleController extends Controller
 {
-    /**
-     * Afficher le solde du portefeuille de l'utilisateur connecté.
-     */
     public function show()
     {
         $portefeuille = Portefeuille::firstOrCreate(
@@ -23,9 +20,6 @@ class PortefeuilleController extends Controller
         ]);
     }
 
-    /**
-     * Créditer le portefeuille (ajout d'argent).
-     */
     public function credit(Request $request)
     {
         $request->validate([
@@ -45,9 +39,6 @@ class PortefeuilleController extends Controller
         ]);
     }
 
-    /**
-     * Débiter le portefeuille (retrait d'argent, optionnel).
-     */
     public function debit(Request $request)
     {
         $request->validate([

--- a/packages/backend/app/Http/Controllers/PrestataireValidationController.php
+++ b/packages/backend/app/Http/Controllers/PrestataireValidationController.php
@@ -96,7 +96,6 @@ class PrestataireValidationController extends Controller
         $prestataire->motif_refus = $validated['motif_refus'] ?? null;
         $prestataire->save();
 
-        // Supprimer tous les justificatifs désormais refusés
         foreach ($prestataire->justificatifs as $justificatif) {
             Storage::disk('public')->delete($justificatif->chemin);
             $justificatif->delete();

--- a/packages/backend/app/Http/Controllers/PrestationController.php
+++ b/packages/backend/app/Http/Controllers/PrestationController.php
@@ -76,7 +76,7 @@ class PrestationController extends Controller
 
         $prestation = new Prestation($validated);
         $prestation->prestataire_id = $user->prestataire->id;
-        $prestation->statut = 'disponible'; // visible par les clients
+        $prestation->statut = 'disponible';
         $prestation->save();
 
         return response()->json([
@@ -128,7 +128,6 @@ class PrestationController extends Controller
             return response()->json(['message' => 'Prestation introuvable.'], 404);
         }
 
-        // Modification impossible dès qu'un client a réservé la prestation
         if ($prestation->client_id !== null) {
             return response()->json(['message' => 'Impossible de modifier une prestation déjà réservée par un client.'], 403);
         }
@@ -168,7 +167,6 @@ class PrestationController extends Controller
             return response()->json(['message' => 'Suppression non autorisée.'], 403);
         }
 
-        // Suppression impossible dès qu'un client a réservé la prestation
         if ($prestation->client_id !== null) {
             return response()->json(['message' => 'Impossible de supprimer une prestation déjà réservée par un client.'], 403);
         }
@@ -193,7 +191,6 @@ class PrestationController extends Controller
             'statut' => 'required|in:acceptée,refusée,terminée',
         ]);
 
-        // ne pas modifier une prestation déjà refusée ou terminée
         if (in_array($prestation->statut, ['refusée', 'terminée'])) {
             return response()->json([
                 'message' => 'Impossible de modifier une prestation finalisée.'
@@ -223,7 +220,6 @@ class PrestationController extends Controller
         $prestation->statut = $nouveauStatut;
         $prestation->save();
 
-        // Créer notification pour le client (si la prestation a bien un client)
         if ($prestation->client_id) {
             Notification::create([
                 'utilisateur_id' => $prestation->client->utilisateur_id ?? null,

--- a/packages/backend/app/Http/Controllers/StatAdminController.php
+++ b/packages/backend/app/Http/Controllers/StatAdminController.php
@@ -8,7 +8,7 @@ use App\Models\Commercant;
 use App\Models\Livreur;
 use App\Models\Prestataire;
 use App\Models\Prestation;
-use App\Models\Commande; // pour les prestations
+use App\Models\Commande;
 use App\Models\EtapeLivraison;
 
 class StatAdminController extends Controller

--- a/packages/backend/app/Http/Controllers/TrajetLivreurController.php
+++ b/packages/backend/app/Http/Controllers/TrajetLivreurController.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\Auth;
 
 class TrajetLivreurController extends Controller
 {
-    // Lister les trajets du livreur connecté
     public function index()
     {
         $user = Auth::user();
@@ -19,7 +18,6 @@ class TrajetLivreurController extends Controller
         return response()->json($trajets);
     }
 
-    // Ajouter un trajet
     public function store(Request $request)
     {
         $user = Auth::user();
@@ -45,7 +43,6 @@ class TrajetLivreurController extends Controller
         return response()->json(['message' => 'Trajet enregistré.', 'trajet' => $trajet]);
     }
 
-    // Supprimer un trajet
     public function destroy($id)
     {
         $trajet = TrajetLivreur::findOrFail($id);

--- a/packages/backend/app/Http/Controllers/UtilisateurController.php
+++ b/packages/backend/app/Http/Controllers/UtilisateurController.php
@@ -9,25 +9,16 @@ use App\Models\Utilisateur;
 
 class UtilisateurController extends Controller
 {
-    /**
-     * Lister tous les utilisateurs.
-     */
     public function index()
     {
         return response()->json(Utilisateur::orderBy('created_at', 'desc')->get());
     }
 
-    /**
-     * Lister tous les livreurs.
-     */
     public function indexLivreurs()
     {
         return Utilisateur::where('role', 'livreur')->get();
     }
 
-    /**
-     * Créer un nouvel utilisateur
-     */
     public function store(Request $request)
     {
         $validated = $request->validate([
@@ -56,7 +47,7 @@ class UtilisateurController extends Controller
             'nom' => $validated['nom'],
             'prenom' => $validated['prenom'],
             'email' => strtolower($validated['email']),
-            'password' => $validated['password'], // hashé via mutator
+            'password' => $validated['password'],
             'role' => $validated['role'],
             'pays' => $validated['pays'] ?? null,
             'telephone' => $validated['telephone'] ?? null,
@@ -70,9 +61,6 @@ class UtilisateurController extends Controller
     }
 
 
-    /**
-     * Afficher un utilisateur spécifique.
-     */
     public function show($id)
     {
         $utilisateur = Utilisateur::find($id);
@@ -85,9 +73,6 @@ class UtilisateurController extends Controller
     }
     
 
-    /**
-     * Modifier un utilisateur.
-     */
     public function update(Request $request, $id)
     {
         $utilisateur = Utilisateur::find($id);
@@ -151,9 +136,6 @@ class UtilisateurController extends Controller
     }
 
 
-    /**
-     * Supprimer un utilisateur.
-     */
     public function destroy($id)
     {
         $utilisateur = Utilisateur::find($id);
@@ -168,7 +150,6 @@ class UtilisateurController extends Controller
             return response()->json(['message' => 'Action non autorisée.'], 403);
         }
 
-        // Supprimer aussi dans la table liée selon le rôle
         match ($utilisateur->role) {
             'client' => $utilisateur->client()?->delete(),
             'livreur' => $utilisateur->livreur()?->delete(),

--- a/packages/backend/app/Http/Middleware/TrustProxies.php
+++ b/packages/backend/app/Http/Middleware/TrustProxies.php
@@ -8,13 +8,7 @@ use Symfony\Component\HttpFoundation\Request;
 class TrustProxies extends Middleware
 {
     
-    // Liste des proxys de confiance.
-    // "*" = tout proxy est accepté (utile pour localhost, nginx, etc.)
-    
     protected $proxies = '*';
 
-    
-    // Headers utilisés pour déterminer IP réelle du client.
-    
     protected $headers = Request::HEADER_X_FORWARDED_ALL;
 }

--- a/packages/backend/app/Http/Resources/AnnonceResource.php
+++ b/packages/backend/app/Http/Resources/AnnonceResource.php
@@ -6,9 +6,6 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class AnnonceResource extends JsonResource
 {
-    /**
-     * Transform the resource into an array.
-     */
     public function toArray($request)
     {
         return [

--- a/packages/backend/app/Http/Resources/PrestationResource.php
+++ b/packages/backend/app/Http/Resources/PrestationResource.php
@@ -6,9 +6,6 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class PrestationResource extends JsonResource
 {
-    /**
-     * Transform the resource into an array.
-     */
     public function toArray($request)
     {
         return [

--- a/packages/backend/app/Models/Annonce.php
+++ b/packages/backend/app/Models/Annonce.php
@@ -73,10 +73,9 @@ class Annonce extends Model
             return 'en_cours';
         }
 
-        // Vérifier si toutes les étapes sont "terminee"
         $toutesTerminees = $etapes->every(fn($e) => $e->statut === 'terminee');
 
-        // Vérifier si l'une des étapes termine à la destination finale
+        
         $destinationFinaleAtteinte = $etapes->contains(function ($e) {
             return $e->lieu_arrivee === $this->entrepotArrivee->ville && $e->statut === 'terminee';
         });

--- a/packages/backend/app/Models/EtapeLivraison.php
+++ b/packages/backend/app/Models/EtapeLivraison.php
@@ -43,11 +43,6 @@ class EtapeLivraison extends Model
         return $this->hasMany(CodeBox::class, 'etape_livraison_id');
     }
 
-    /**
-     * Détermine si le retrait peut être validé pour cette étape.
-     * Il ne doit exister aucune étape précédente de la même annonce
-     * créée pour le client ou le commerçant qui n'est pas encore terminée.
-     */
     public function peutRetirer(): bool
     {
         return !self::where('annonce_id', $this->annonce_id)

--- a/packages/backend/app/Models/Utilisateur.php
+++ b/packages/backend/app/Models/Utilisateur.php
@@ -32,7 +32,6 @@ class Utilisateur extends Authenticatable implements MustVerifyEmail
         'remember_token',
     ];
 
-    // Mutator pour hasher automatiquement le mot de passe
     public function setPasswordAttribute($value)
     {
         if (!empty($value)) {
@@ -40,26 +39,22 @@ class Utilisateur extends Authenticatable implements MustVerifyEmail
         }
     }
 
-    // Annonces créées par le client (type livraison_client ou produit_livre)
     public function annoncesClient()
     {
         return $this->hasMany(Annonce::class, 'id_client');
     }
 
-    // Annonces créées par le commerçant (type produit_livre)
     public function annoncesCommercant()
     {
         return $this->hasMany(Annonce::class, 'id_commercant');
     }
 
 
-    // Annonces pour lesquelles l'utilisateur est livreur
     public function livraisons()
     {
         return $this->belongsToMany(Annonce::class, 'annonce_utilisateur', 'utilisateur_id', 'annonce_id');
     }
 
-    // Commandes faites par ce client
     public function commandes()
     {
         return $this->hasMany(Commande::class, 'client_id');

--- a/packages/backend/app/Observers/EntrepotObserver.php
+++ b/packages/backend/app/Observers/EntrepotObserver.php
@@ -7,9 +7,6 @@ use App\Services\BoxService;
 
 class EntrepotObserver
 {
-    /**
-     * Handle the Entrepot "created" event.
-     */
     public function created(Entrepot $entrepot): void
     {
         BoxService::createDefaultBoxes($entrepot);

--- a/packages/backend/app/Policies/PrestationPolicy.php
+++ b/packages/backend/app/Policies/PrestationPolicy.php
@@ -8,9 +8,6 @@ use Illuminate\Support\Facades\Log;
 
 class PrestationPolicy
 {
-    /**
-     * Determine if the authenticated user can pay for the prestation.
-     */
     public function pay(Utilisateur $user, Prestation $prestation): bool
     {
         if (! $user->relationLoaded('client')) {
@@ -21,8 +18,7 @@ class PrestationPolicy
             return false;
         }
 
-        // If no client is attached yet, allow payment only when the prestation
-        // is available so it can be reserved afterwards
+        // Autoriser le paiement uniquement si la prestation est disponible lorsque aucun client n'est encore associé
         if ($prestation->client_id === null) {
             return $prestation->statut === 'disponible';
         }
@@ -34,14 +30,9 @@ class PrestationPolicy
         return $prestation->client->utilisateur_id === $user->id;
     }
 
-    /**
-     * Determine if the authenticated user can reserve the prestation.
-     * The user must be a client and, if a client is already associated
-     * to the prestation, it must be the same one.
-     */
+
     public function reserver(Utilisateur $user, Prestation $prestation): bool
     {
-        // Ensure the client relation is loaded for the authenticated user
         if (! $user->relationLoaded('client')) {
             $user->load('client');
         }

--- a/packages/backend/app/Providers/AppServiceProvider.php
+++ b/packages/backend/app/Providers/AppServiceProvider.php
@@ -7,19 +7,13 @@ use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
 {
-    /**
-     * Register any application services.
-     */
     public function register()
     {
-       
+
     }
 
-    /**
-     * Bootstrap any application services.
-     */
     public function boot()
     {
-       
+
     }
 }

--- a/packages/backend/app/Providers/AuthServiceProvider.php
+++ b/packages/backend/app/Providers/AuthServiceProvider.php
@@ -10,11 +10,6 @@ use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvid
 
 class AuthServiceProvider extends ServiceProvider
 {
-    /**
-     * The policy mappings for the application.
-     *
-     * @var array<class-string, class-string>
-     */
     protected $policies = [
         Annonce::class => AnnoncePolicy::class,
         Prestation::class => PrestationPolicy::class,

--- a/packages/backend/app/Providers/BackendServiceProvider.php
+++ b/packages/backend/app/Providers/BackendServiceProvider.php
@@ -8,12 +8,10 @@ class BackendServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        // Charge les routes
         $this->loadRoutesFrom(base_path('routes/api.php'));
     }
 
     public function register()
     {
-        // Vide pour l’instant (ne rien faire ici)
     }
 }

--- a/packages/backend/app/Providers/EventServiceProvider.php
+++ b/packages/backend/app/Providers/EventServiceProvider.php
@@ -8,13 +8,7 @@ use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvi
 
 class EventServiceProvider extends ServiceProvider
 {
-    /**
-     * The event listener mappings for the application.
-     *
-     * @var array<class-string, array<int, class-string>>
-     */
     protected $listen = [
-        //
     ];
 
     public function boot(): void

--- a/packages/backend/app/Providers/FortifyServiceProvider.php
+++ b/packages/backend/app/Providers/FortifyServiceProvider.php
@@ -15,24 +15,16 @@ use Laravel\Fortify\Fortify;
 
 class FortifyServiceProvider extends ServiceProvider
 {
-    /**
-     * Register any application services.
-     */
     public function register(): void
     {
-        //
     }
 
-    /**
-     * Bootstrap any application services.
-     */
     public function boot(): void
     {
         Fortify::createUsersUsing(CreateNewUser::class);
         Fortify::updateUserProfileInformationUsing(UpdateUserProfileInformation::class);
         Fortify::updateUserPasswordsUsing(UpdateUserPassword::class);
         Fortify::resetUserPasswordsUsing(ResetUserPassword::class);
-        // Fortify::redirectUserForTwoFactorAuthenticationUsing(RedirectIfTwoFactorAuthenticatable::class);
 
         RateLimiter::for('login', function (Request $request) {
             $throttleKey = Str::transliterate(Str::lower($request->input(Fortify::username())).'|'.$request->ip());

--- a/packages/backend/app/Services/BoxService.php
+++ b/packages/backend/app/Services/BoxService.php
@@ -7,9 +7,6 @@ use Illuminate\Support\Str;
 
 class BoxService
 {
-    /**
-     * Create the default boxes for a warehouse.
-     */
     public static function createDefaultBoxes(Entrepot $entrepot): void
     {
         $boxes = [];

--- a/packages/backend/app/Services/LivraisonService.php
+++ b/packages/backend/app/Services/LivraisonService.php
@@ -13,9 +13,6 @@ use Illuminate\Support\Facades\DB;
 
 class LivraisonService
 {
-    /**
-     * Crée une nouvelle étape réelle à partir d'un dépôt intermédiaire.
-     */
     public static function creerNouvelleEtapeDepuisDepotIntermediaire(Annonce $annonce, Utilisateur $livreur): ?EtapeLivraison
     {
         if (!$annonce->is_paid) {


### PR DESCRIPTION
## Summary
- remove trivial comments and AI hints across backend app
- sanitize messages with emojis
- keep business logic unchanged

## Testing
- `composer install --no-interaction`
- `./vendor/bin/phpunit --dont-report-useless-tests` *(fails: MissingAppKeyException)*

------
https://chatgpt.com/codex/tasks/task_e_6876221e93e883318c31d14004f67714