### PR TITLE
Clean backoffice code

### DIFF
--- a/packages/frontend/backoffice/src/App.jsx
+++ b/packages/frontend/backoffice/src/App.jsx
@@ -8,10 +8,8 @@ export default function App() {
   return (
     <Router>
       <Routes>
-        {/* Page de login */}
         <Route path="/login" element={<Login />} />
 
-        {/* Espace admin protégé */}
         <Route
           path="/admin/*"
           element={
@@ -23,7 +21,6 @@ export default function App() {
           }
         />
 
-        {/* Redirection automatique */}
         <Route path="*" element={<Navigate to="/admin" />} />
       </Routes>
     </Router>

--- a/packages/frontend/backoffice/src/pages/admin/AdminPrestataires.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/AdminPrestataires.jsx
@@ -197,7 +197,7 @@ export default function AdminPrestataires() {
                 <li key={e.id} className="mb-2">
                   <span className="font-medium">{e.prestation.type_prestation}</span>
                   {" - "}
-                  {new Date(e.prestation.date_heure).toLocaleDateString()} - {e.note}/5 ⭐
+                  {new Date(e.prestation.date_heure).toLocaleDateString()} - {e.note}/5
                   {e.commentaire_client && <p>{e.commentaire_client}</p>}
                 </li>
               ))}

--- a/packages/frontend/backoffice/src/pages/admin/PrestationList.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/PrestationList.jsx
@@ -70,7 +70,6 @@ export default function PrestationList() {
     }
   }
 
-  // A prestation is considered engaged only if a client has booked it
   const isEngagee = (p) => p.client_id != null;
 
   const startEdit = (prestation) => {

--- a/packages/frontend/backoffice/src/services/paiement.js
+++ b/packages/frontend/backoffice/src/services/paiement.js
@@ -2,6 +2,6 @@ import api from "./api";
 
 export async function fetchPaiements() {
   const res = await api.get("/paiements");
-  // ⚠️ L'API renvoie uniquement les paiements de l'utilisateur connecté.
+  // L'API renvoie uniquement les paiements de l'utilisateur connecté.
   return res.data;
 }


### PR DESCRIPTION
## Summary
- remove leftover React comments
- strip unused comment from PrestationList
- drop star emoji in AdminPrestataires
- edit API comment without emoji

## Testing
- `npm --prefix packages/frontend/backoffice run lint`

------
https://chatgpt.com/codex/tasks/task_e_68762e99b59c8331a90ec051740075a3