### PR TITLE
Display document type in admin list

### DIFF
--- a/packages/frontend/backoffice/src/pages/admin/AdminLivreur.jsx
+++ b/packages/frontend/backoffice/src/pages/admin/AdminLivreur.jsx
@@ -3,6 +3,11 @@ import api from "../../services/api";
 
 const STORAGE_BASE_URL = api.defaults.baseURL.replace("/api", "");
 
+const labelType = {
+  piece_identite: "Pièce d'identité",
+  permis_conduire: "Permis de conduire",
+};
+
 export default function AdminLivreur() {
   const [livreurs, setLivreurs] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -168,13 +173,17 @@ export default function AdminLivreur() {
           <ul className="list-disc ml-6">
             {files.map((f) => (
               <li key={f.id}>
+                <span className="mr-2 font-medium">
+                  {labelType[f.type] || f.type}
+                </span>
+                –
                 <a
                   href={`${STORAGE_BASE_URL}/storage/${f.chemin}`}
                   target="_blank"
                   rel="noreferrer"
-                  className="text-blue-600 underline"
+                  className="ml-2 text-blue-600 underline"
                 >
-                  {f.chemin}
+                  Télécharger fichier
                 </a>
               </li>
             ))}


### PR DESCRIPTION
## Summary
- show a readable label for each document type in `AdminLivreur`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6877f9e5de988331969d54204a2b9c84